### PR TITLE
patch to avoid segfault

### DIFF
--- a/collada_urdf/include/collada_urdf/collada_urdf.h
+++ b/collada_urdf/include/collada_urdf/collada_urdf.h
@@ -50,40 +50,12 @@ public:
     ColladaUrdfException(std::string const& what);
 };
 
-/** Construct a COLLADA DOM from an URDF file
- * \param file The filename from where to read the URDF
- * \param dom The resulting COLLADA DOM
- * \return true on success, false on failure
- */
-bool colladaFromUrdfFile(std::string const& file, boost::shared_ptr<DAE>& dom);
-
-/** Construct a COLLADA DOM from a string containing URDF
- * \param xml A string containing the XML description of the robot
- * \param dom The resulting COLLADA DOM
- * \return true on success, false on failure
- */
-bool colladaFromUrdfString(std::string const& xml, boost::shared_ptr<DAE>& dom);
-
-/** Construct a COLLADA DOM from a TiXmlDocument containing URDF
- * \param xml_doc The TiXmlDocument containing URDF
- * \param dom The resulting COLLADA DOM
- * \return true on success, false on failure
- */
-bool colladaFromUrdfXml(TiXmlDocument* xml_doc, boost::shared_ptr<DAE>& dom);
-
-/** Construct a COLLADA DOM from a URDF robot model
- * \param robot_model The URDF robot model
- * \param dom The resulting COLLADA DOM
- * \return true on success, false on failure
- */
-bool colladaFromUrdfModel(urdf::Model const& robot_model, boost::shared_ptr<DAE>& dom);
-
 /** Write a COLLADA DOM to a file
- * \param dom COLLADA DOM to write
+ * \param robot_model The URDF robot model
  * \param file The filename to write the document to
  * \return true on success, false on failure
  */
-bool colladaToFile(boost::shared_ptr<DAE> dom, std::string const& file);
+bool WriteUrdfModelToColladaFile(urdf::Model const& robot_model, std::string const& file);
 
 }
 

--- a/collada_urdf/src/urdf_to_collada.cpp
+++ b/collada_urdf/src/urdf_to_collada.cpp
@@ -54,13 +54,7 @@ int main(int argc, char** argv)
         ROS_ERROR("failed to open urdf file %s",input_filename.c_str());
     }
 
-    boost::shared_ptr<DAE> dom;
-    if (!collada_urdf::colladaFromUrdfModel(robot_model, dom)) {
-        std::cerr << std::endl << "Error converting document" << std::endl;
-        return -1;
-    }
-
-    collada_urdf::colladaToFile(dom, output_filename);
+    collada_urdf::WriteUrdfModelToColladaFile(robot_model, output_filename);
     std::cout << std::endl << "Document successfully written to " << output_filename << std::endl;
 
     return 0;


### PR DESCRIPTION
here is a patch to avoid segfault reported on #4
Instead of useng shared pointer, this code uses objects itself, please note that I'm not fully understand why this patch solves the problem, i.e. why shared pointer _collada is broken, so please be careful to use this solution
