### PR TITLE
joint_state_publisher: fixed crash when source_cb directly updates sliders

### DIFF
--- a/visualization/joint_state_publisher/joint_state_publisher
+++ b/visualization/joint_state_publisher/joint_state_publisher
@@ -3,6 +3,7 @@
 import roslib; roslib.load_manifest('joint_state_publisher')
 import rospy
 import wx
+import wx.lib.newevent
 import xml.dom.minidom
 from sensor_msgs.msg import JointState
 from math import pi
@@ -135,7 +136,8 @@ class JointStatePublisher():
                 joint['effort'] = effort
 
         if self.gui is not None:
-            self.gui.update_sliders()
+            # post an event here instead of directly calling the update_sliders method, to switch to the wx thread
+            wx.PostEvent(self.gui.GetEventHandler(), self.gui.UpdateSlidersEvent())
         
 
     def loop(self):
@@ -253,6 +255,9 @@ class JointStatePublisherGui(wx.Frame):
             self.joint_map[name] = {'slidervalue':0, 'display':display, 
                                     'slider':slider, 'joint':joint}
 
+        self.UpdateSlidersEvent, self.EVT_UPDATESLIDERS = wx.lib.newevent.NewEvent()
+        self.Bind(self.EVT_UPDATESLIDERS, self.updateSliders)
+        
         ### Buttons ###
         self.ctrbutton = wx.Button(panel, 1, 'Center')
         self.Bind(wx.EVT_SLIDER, self.sliderUpdate)
@@ -273,6 +278,9 @@ class JointStatePublisherGui(wx.Frame):
             joint = joint_info['joint']
             value = self.sliderToValue(purevalue, joint)
             joint['position'] = value
+        self.update_sliders()
+
+    def updateSliders(self, event):
         self.update_sliders()
 
     def update_sliders(self):


### PR DESCRIPTION
When the JSP updates the wx sliders directly from the ros subscriber callback, it crashes reproducibly. Going through a wx event to update the sliders fixes this,
Errors that were produced by the old version range from assert failures to stack corruption...:
(python:18864): GLib-GObject-CRITICAL **: g_object_unref: assertion `G_IS_OBJECT (object)' failed

**\* glibc detected **\* /usr/bin/python: double free or corruption (fasttop): 0x00007f92ac01b390 ***
======= Backtrace: =========
/lib/x86_64-linux-gnu/libc.so.6(+0x7eb96)[0x7f92cbf11b96]
...
