### PR TITLE
installing joint state publisher so that it can be used by rosrun

### DIFF
--- a/joint_state_publisher/CMakeLists.txt
+++ b/joint_state_publisher/CMakeLists.txt
@@ -6,3 +6,5 @@ find_package(catkin)
 catkin_python_setup()
 
 catkin_package()
+
+install(PROGRAMS joint_state_publisher/joint_state_publisher DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})


### PR DESCRIPTION
As of right now, `setup.py` is installing `joint_state_publisher` into the global bin folder instead of joint_state_publisher's bin folder. This prevents `rosrun` from running joint_state_publisher. With this patch, it will be installed in both places. 

See https://github.com/ros/xacro/issues/1 for the same discussion on xacro. An alternative is to change setup.py to install correctly. I have followed xacro's current logic in this patch
