### PR TITLE
change Z_UP to Y_UP for default <up_axis> on collada_parser

### DIFF
--- a/collada_parser/src/collada_parser.cpp
+++ b/collada_parser/src/collada_parser.cpp
@@ -1187,7 +1187,7 @@ protected:
       </comments>\n\
     </contributor>\n\
     <unit name=\"meter\" meter=\"1.0\"/>\n\
-    <up_axis>Z_UP</up_axis>\n\
+    <up_axis>Y_UP</up_axis>\n\
   </asset>\n\
   <library_materials>\n"));
         for(unsigned int i=0; i < index; i++) {


### PR DESCRIPTION
Changing Z_UP to Y_UP for default <up_axis> on collada_parser, 
it would effect to programs using assimp.

Assimp library transforms vertices if mesh files set <up_axis> other than Y_UP.
So in moveit, collision checking would return wrong results.
