### PR TITLE
joint_state_publisher: do not install script to global bin

### DIFF
--- a/joint_state_publisher/CMakeLists.txt
+++ b/joint_state_publisher/CMakeLists.txt
@@ -1,9 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(joint_state_publisher)
 
-find_package(catkin)
-
-catkin_python_setup()
+find_package(catkin REQUIRED)
 
 catkin_package()
 

--- a/joint_state_publisher/joint_state_publisher/joint_state_publisher
+++ b/joint_state_publisher/joint_state_publisher/joint_state_publisher
@@ -1,6 +1,5 @@
 #!/usr/bin/python
 
-import roslib; roslib.load_manifest('joint_state_publisher')
 import rospy
 import wx
 import wx.lib.newevent

--- a/joint_state_publisher/package.xml
+++ b/joint_state_publisher/package.xml
@@ -11,12 +11,12 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>rospy</build_depend> 
-  <build_depend>wxpython</build_depend> 
-  <build_depend>sensor_msgs</build_depend> 
+  <build_depend>rospy</build_depend>
+  <build_depend>wxpython</build_depend>
+  <build_depend>sensor_msgs</build_depend>
 
-  <run_depend>rospy</run_depend> 
-  <run_depend>wxpython</run_depend> 
-  <run_depend>sensor_msgs</run_depend> 
+  <run_depend>rospy</run_depend>
+  <run_depend>wxpython</run_depend>
+  <run_depend>sensor_msgs</run_depend>
 
 </package>

--- a/joint_state_publisher/setup.py
+++ b/joint_state_publisher/setup.py
@@ -1,9 +1,0 @@
-from distutils.core import setup
-from catkin_pkg.python_setup import generate_distutils_setup
-
-d = generate_distutils_setup()
-d['packages'] = []
-d['scripts'] = ['joint_state_publisher/joint_state_publisher']
-d['package_dir'] = {}
-
-setup(**d)


### PR DESCRIPTION
Also clean up no longer required setup.py

If this was intended someone tell me, but really I don't think `joint_state_publisher` should be in the global path.
