### PR TITLE
Update KDL SegmentMap interface to use shared pointers

### DIFF
--- a/kdl_parser/src/check_kdl_parser.cpp
+++ b/kdl_parser/src/check_kdl_parser.cpp
@@ -46,11 +46,11 @@ using namespace urdf;
 
 void printLink(const SegmentMap::const_iterator& link, const std::string& prefix)
 {
-  cout << prefix << "- Segment " << link->second.segment.getName() << " has " << link->second.children.size() << " children" << endl;
-  for (unsigned int i=0; i<link->second.children.size(); i++)
-    printLink(link->second.children[i], prefix + "  ");
+  cout << prefix << "- Segment " << GetTreeElementSegment(link->second).getName() << " has "
+       << GetTreeElementChildren(link->second).size() << " children" << endl;
+  for (unsigned int i=0; i < GetTreeElementChildren(link->second).size(); i++)
+      printLink(GetTreeElementChildren(link->second)[i], prefix + "  ");
 }
-
 
 
 int main(int argc, char** argv)


### PR DESCRIPTION
This is a dependent change for the orocos KDL API modification discussed in: orocos/orocos_kinematics_dynamics#4

To summarize the KDL API used incomplete type definitions in STL containers, which is undefined behaviour according the c++ standard. As it was, GCC / libstc++ handles this behaviour with problems; however, on systems with clang/libc++ using incomplete type definitions in STL containers results in compilation errors. Instead a solution involving shared pointers has been proposed. More rational the change is discussed in the upstream pull request.

The upstream pull request is necessary for this change to be merged.
