### PR TITLE
Use #!/usr/bin/env python for systems with multiple Python versions.

### DIFF
--- a/joint_state_publisher/joint_state_publisher/joint_state_publisher
+++ b/joint_state_publisher/joint_state_publisher/joint_state_publisher
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import rospy
 import wx


### PR DESCRIPTION
I had problems on Arch Linux since the system's default Python version is Python 3.
