### PR TITLE
Use assimp-dev dep for building

### DIFF
--- a/collada_urdf/package.xml
+++ b/collada_urdf/package.xml
@@ -19,7 +19,7 @@
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 
   <build_depend>angles</build_depend>
-  <build_depend>assimp</build_depend>
+  <build_depend>assimp-dev</build_depend>
   <build_depend>resource_retriever</build_depend>
   <build_depend>collada-dom</build_depend>
   <build_depend>collada_parser</build_depend>


### PR DESCRIPTION
The assimp-dev dep has existed for a while now. We should use that for building and leave the runtime dep as-is.

See https://github.com/ros/rosdistro/commit/a506ef945febc0cd886bbc29ab976751d1cb1f3b
