### PR TITLE
Update KDL SegmentMap interface to optionally use shared pointers

### DIFF
--- a/kdl_parser/src/check_kdl_parser.cpp
+++ b/kdl_parser/src/check_kdl_parser.cpp
@@ -46,11 +46,11 @@ using namespace urdf;
 
 void printLink(const SegmentMap::const_iterator& link, const std::string& prefix)
 {
-  cout << prefix << "- Segment " << link->second.segment.getName() << " has " << link->second.children.size() << " children" << endl;
-  for (unsigned int i=0; i<link->second.children.size(); i++)
-    printLink(link->second.children[i], prefix + "  ");
+  cout << prefix << "- Segment " << GetTreeElementSegment(link->second).getName() << " has "
+       << GetTreeElementChildren(link->second).size() << " children" << endl;
+  for (unsigned int i=0; i < GetTreeElementChildren(link->second).size(); i++)
+      printLink(GetTreeElementChildren(link->second)[i], prefix + "  ");
 }
-
 
 
 int main(int argc, char** argv)


### PR DESCRIPTION
The KDL Tree API optionally uses shared pointers on platforms where
the STL containers don't support incomplete types.

This is the same change as in #43 but for the indigo-devel branch.
