### PR TITLE
storing original mesh file name and location

### DIFF
--- a/collada_urdf/src/collada_urdf.cpp
+++ b/collada_urdf/src/collada_urdf.cpp
@@ -1282,6 +1282,7 @@ protected:
         switch (geometry->type) {
         case urdf::Geometry::MESH: {
             urdf::Mesh* urdf_mesh = (urdf::Mesh*) geometry.get();
+	    cgeometry->setName(urdf_mesh->filename.c_str());
             _loadMesh(urdf_mesh->filename, cgeometry, urdf_mesh->scale, org_trans);
             break;
         }


### PR DESCRIPTION
I need a collada file which have the original  mesh file name and location on a urdf file.
It is useful for reconstructing texture mapping information.
