### PR TITLE
Fix clash with assimp 3.1 in CMake.

### DIFF
--- a/collada_urdf/CMakeLists.txt
+++ b/collada_urdf/CMakeLists.txt
@@ -12,9 +12,6 @@ catkin_package(
 
 include_directories(include)
 
-find_package(Boost REQUIRED COMPONENTS system filesystem program_options)
-include_directories(${Boost_INCLUDE_DIR})
-
 find_package(assimp QUIET)
 if ( NOT ASSIMP_FOUND )
   find_package(Assimp QUIET)
@@ -41,6 +38,11 @@ else()
   set(ASSIMP_LINK_FLAGS)
   set(ASSIMP_INCLUDE_DIRS)
 endif()
+
+# Note: assimp 3.1 overwrites CMake Boost variables, so we need to check for
+# Boost after assimp.
+find_package(Boost REQUIRED COMPONENTS system filesystem program_options)
+include_directories(${Boost_INCLUDE_DIR})
 
 find_package(COLLADA_DOM 2.3 COMPONENTS 1.5)
 if( COLLADA_DOM_FOUND )


### PR DESCRIPTION
This bug is happening on Arch Linux with the latest assimp (3.1). The cause is the same one I described in https://github.com/assimp/assimp/issues/282, i.e. a bunch of code was previously ignored because of a `if(WIN32)` check. Until they fix it and release it, we need to check for Boost after assimp.

Original bug reported on the AUR: https://aur.archlinux.org/packages/ros-hydro-collada-urdf/
