### PR TITLE
kdl_parser: Adding python kdl parser

### DIFF
--- a/kdl_parser/CMakeLists.txt
+++ b/kdl_parser/CMakeLists.txt
@@ -47,3 +47,5 @@ install(TARGETS ${PROJECT_NAME}
 
 install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
+
+catkin_python_setup()

--- a/kdl_parser/package.xml
+++ b/kdl_parser/package.xml
@@ -30,5 +30,7 @@
   <run_depend>rosconsole</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>urdf</run_depend>
+  <run_depend>urdf_parser_py</run_depend>
+  <run_depend>python_orocos_kdl</run_depend>
 
 </package>

--- a/kdl_parser/setup.py
+++ b/kdl_parser/setup.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+
+from distutils.core import setup
+from catkin_pkg.python_setup import generate_distutils_setup
+
+d = generate_distutils_setup(
+   packages=['kdl_parser'],
+   package_dir={'': 'src'}
+)
+
+setup(**d)

--- a/kdl_parser/src/kdl_parser/urdf.py
+++ b/kdl_parser/src/kdl_parser/urdf.py
@@ -1,0 +1,125 @@
+
+from __future__ import print_function
+
+import urdf_parser_py.urdf as urdf
+
+import PyKDL as kdl
+
+def treeFromFile(filename):
+    """
+    Construct a PyKDL.Tree from an URDF file.
+    :param filename: URDF file path
+    """
+
+    with open(filename) as urdf_file:
+        return treeFromUrdfModel(urdf.URDF.from_xml_string(urdf_file.read()))
+
+def treeFromParam(param):
+    """
+    Construct a PyKDL.Tree from an URDF in a ROS parameter.
+    :param param: Parameter name, ``str``
+    """
+
+    return treeFromUrdfModel(urdf.URDF.from_parameter_server())
+
+def treeFromString(xml):
+    """
+    Construct a PyKDL.Tree from an URDF xml string.
+    :param xml: URDF xml string, ``str``
+    """
+
+    return treeFromUrdfModel(urdf.URDF.from_xml_string(xml))
+
+def _toKdlPose(pose):
+    if pose:
+        return kdl.Frame(
+              kdl.Rotation.RPY(*pose.rpy),
+              kdl.Vector(*pose.xyz))
+    else:
+        return kdl.Frame.Identity()
+
+def _toKdlInertia(i):
+    # kdl specifies the inertia in the reference frame of the link, the urdf
+    # specifies the inertia in the inertia reference frame
+    origin = _toKdlPose(i.origin)
+    inertia = i.inertia
+    return origin.M * kdl.RigidBodyInertia(
+            i.mass, origin.p,
+            kdl.RotationalInertia(inertia.ixx, inertia.iyy, inertia.izz, inertia.ixy, inertia.ixz, inertia.iyz));
+
+def _toKdlJoint(jnt):
+
+    fixed = lambda j,F: kdl.Joint(j.name, kdl.Joint.None)
+    rotational = lambda j,F: kdl.Joint(j.name, F.p, F.M * kdl.Vector(*j.axis), kdl.Joint.RotAxis)
+    translational = lambda j,F: kdl.Joint(j.name, F.p, F.M * kdl.Vector(*j.axis), kdl.Joint.TransAxis)
+
+    type_map = {
+            'fixed': fixed,
+            'revolute': rotational, 
+            'continuous': rotational,
+            'prismatic': translational,
+            'floating': fixed,
+            'planar': fixed,
+            'unknown': fixed,
+            }
+
+    return type_map[jnt.type](jnt, _toKdlPose(jnt.origin))
+
+def _add_children_to_tree(robot_model, root, tree):
+
+
+    # constructs the optional inertia
+    inert = kdl.RigidBodyInertia(0)
+    if root.inertial:
+        inert = _toKdlInertia(root.inertial)
+
+    # constructs the kdl joint
+    (parent_joint_name, parent_link_name) = robot_model.parent_map[root.name]
+    parent_joint = robot_model.joint_map[parent_joint_name]
+
+    # construct the kdl segment
+    sgm = kdl.Segment(
+        root.name, 
+        _toKdlJoint(parent_joint), 
+        _toKdlPose(parent_joint.origin), 
+        inert)
+
+    # add segment to tree
+    if not tree.addSegment(sgm, parent_link_name):
+        return False
+
+    if root.name not in robot_model.child_map:
+        return True
+
+    children = [robot_model.link_map[l] for (j,l) in robot_model.child_map[root.name]]
+
+    # recurslively add all children
+    for child in children:
+        if not _add_children_to_tree(robot_model, child, tree):
+            return False
+
+    return True;
+
+def treeFromUrdfModel(robot_model, quiet=False):
+    """
+    Construct a PyKDL.Tree from an URDF model from urdf_parser_python.
+
+    :param robot_model: URDF xml string, ``str``
+    :param quiet: If true suppress messages to stdout, ``bool``
+    """
+
+    root = robot_model.link_map[robot_model.get_root()]
+
+    if root.inertial and not quiet:
+        print("The root link %s has an inertia specified in the URDF, but KDL does not support a root link with an inertia.  As a workaround, you can add an extra dummy link to your URDF." % root.name);
+
+    ok = True
+    tree = kdl.Tree(root.name)
+
+    #  add all children
+    for (joint,child) in robot_model.child_map[root.name]:
+        if not _add_children_to_tree(robot_model, robot_model.link_map[child], tree):
+            ok = False
+            break
+  
+    return (ok, tree)


### PR DESCRIPTION
Example:

``` python
import kdl_parser
(ok, tree) = kdl_parser.urdf.treeFromFile('/path/to/file.urdf')
```
