### PR TITLE
update usage of urdfdom_headers for indigo/trusty

### DIFF
--- a/collada_parser/CMakeLists.txt
+++ b/collada_parser/CMakeLists.txt
@@ -3,7 +3,8 @@ project(collada_parser)
 
 find_package(Boost REQUIRED system)
 
-find_package(catkin REQUIRED COMPONENTS urdfdom_headers urdf_parser_plugin roscpp class_loader)
+find_package(catkin REQUIRED COMPONENTS urdf_parser_plugin roscpp class_loader)
+find_package(urdfdom_headers REQUIRED)
 
 catkin_package( 
   LIBRARIES ${PROJECT_NAME}
@@ -13,7 +14,7 @@ catkin_package(
 )
 
 include_directories(${Boost_INCLUDE_DIR})
-include_directories(include ${catkin_INCLUDE_DIRS})
+include_directories(include ${catkin_INCLUDE_DIRS} ${urdfdom_headers_INCLUDE_DIRS})
 
 set(CMAKE_MODULE_PATH  ${PROJECT_SOURCE_DIR}/cmake-extensions/)
 find_package(PkgConfig)

--- a/urdf_parser_plugin/CMakeLists.txt
+++ b/urdf_parser_plugin/CMakeLists.txt
@@ -1,14 +1,13 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(urdf_parser_plugin)
 
-find_package(catkin REQUIRED urdfdom_headers)
+find_package(catkin REQUIRED)
+find_package(urdfdom_headers REQUIRED)
 
 catkin_package(
   INCLUDE_DIRS include
   DEPENDS urdfdom_headers 
 )
-
-include_directories(include)
 
 install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})


### PR DESCRIPTION
This is needed because of the shake up of the `urdfdom`, `urdfdom_headers`, and `console_bridge` packages for Trusty and Indigo.

See: https://github.com/ros/rosdistro/issues/4633
