### PR TITLE
add libpcrecpp, without this patch, pcrecpp always fails > 13.04

### DIFF
--- a/urdf/CMakeLists.txt
+++ b/urdf/CMakeLists.txt
@@ -8,11 +8,14 @@ find_package(catkin REQUIRED COMPONENTS
 
 find_package(TinyXML REQUIRED)
 
+find_package(PkgConfig)
+pkg_check_modules(libpcrecpp libpcrecpp)
+
 catkin_package(
   LIBRARIES ${PROJECT_NAME}
   INCLUDE_DIRS include ${TinyXML_INCLUDE_DIRS}
   CATKIN_DEPENDS rosconsole_bridge roscpp
-  DEPENDS urdfdom_headers urdfdom Boost
+  DEPENDS urdfdom_headers urdfdom Boost pcrecpp
 )
 
 include_directories(SYSTEM ${Boost_INCLUDE_DIR})
@@ -27,7 +30,7 @@ include_directories(
 link_directories(${catkin_LIBRARY_DIRS})
 
 add_library(${PROJECT_NAME} src/model.cpp src/rosconsole_bridge.cpp)
-target_link_libraries(${PROJECT_NAME} ${TinyXML_LIBRARIES} ${catkin_LIBRARIES} ${urdfdom_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${TinyXML_LIBRARIES} ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${libpcrecpp_LIBRARIES})
 
 if(APPLE)
   set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")

--- a/urdf/package.xml
+++ b/urdf/package.xml
@@ -21,6 +21,7 @@
 
   <build_depend>rosconsole_bridge</build_depend>
   <build_depend>roscpp</build_depend>
+  <build_depend>pcre</build_depend>
   <build_depend>urdfdom</build_depend>
   <build_depend>urdfdom_headers</build_depend>
   <build_depend>urdf_parser_plugin</build_depend>
@@ -30,6 +31,7 @@
 
   <run_depend>rosconsole_bridge</run_depend>
   <run_depend>roscpp</run_depend>
+  <run_depend>pcre</run_depend>
   <run_depend>urdfdom</run_depend>
   <run_depend>urdfdom_headers</run_depend>
   <run_depend>urdf_parser_plugin</run_depend>

--- a/urdf/src/model.cpp
+++ b/urdf/src/model.cpp
@@ -52,6 +52,9 @@
 #include <fstream>
 #include <iostream>
 
+#include <pcrecpp.h>
+pcrecpp::RE __re__("");
+
 namespace urdf{
 
 static bool IsColladaData(const std::string& data)


### PR DESCRIPTION
state_publisher fails with ubuntu 13.04 and higher with   `Trying to load an invalid COLLADA version for this DOM build` 
Here is how you reproduce this.

```
$ rosparam set /robot_description -t `rospack find nextage_description`/models/main.dae # https://github.com/tork-a/rtmros_nextage/tree/hydro-devel/nextage_description/models
```

```
$ rosrun robot_state_publisher state_publisher
[ERROR] [1405529535.299984046]: COLLADA error: Trying to load an invalid COLLADA version for this DOM build!
[ERROR] [1405529535.343770418]: COLLADA error: Failed to load XML document from memory
[ERROR] [1405529535.356754079]: Could not generate robot model
[ERROR] [1405529535.360128130]: Failed to extract kdl tree from xml robot description
```

but on 12.04, `state_publisher` works and collada_to_urdf also works even inf it uses same function to load collada model files as state_publish (openFromMemory function https://github.com/ros/robot_model/blob/indigo-devel/collada_parser/src/collada_parser.cpp#L444 via
https://github.com/ros/robot_model/blob/indigo-devel/collada_urdf/src/collada_to_urdf.cpp#L674)

```
$ rosrun collada_urdf collada_to_urdf main.dae 
;; Input file is: main.dae
[ WARN] [1405531921.704972653]: COLLADA warning: The DOM was unable to create an element named copyright at line 10. Probably a schema violation.
[ERROR] [1405531921.906564327]: Target Node visual1/node_joint0_axis0 NOT found!!!
[ WARN] [1405531921.922642311]: could not find binding for axis: kmodel1/jointsid1000/axis0, axis0
[ WARN] [1405531921.927932124]: could not find binding for axis: kmodel1/jointsid1000/axis0, axis0
```

What I found is ..
- pcrecpp::FullMatch always fails on 13.04 and higher (https://github.com/rdiankov/collada-dom/blob/master/dom/src/dae/daeURI.cpp#L751)
- collada_to_urdf directly links colada_parasr and collada-dom, but state_publisher user collada_parser through urdf_parser_plugin.

I still could not find good workaround but if state_publisher loads pcrecpp before it loads collada_parser, then it works fine.

see https://github.com/rdiankov/collada-dom/issues/7 for original post.
