### PR TITLE
Added floating joints to joint types ignored by publisher

### DIFF
--- a/joint_state_publisher/joint_state_publisher/joint_state_publisher
+++ b/joint_state_publisher/joint_state_publisher/joint_state_publisher
@@ -41,7 +41,7 @@ class JointStatePublisher():
                 continue
             if child.localName == 'joint':
                 jtype = child.getAttribute('type')
-                if jtype == 'fixed':
+                if jtype == 'fixed' or jtype == 'floating':
                     continue
                 name = child.getAttribute('name')
                 self.joint_list.append(name)


### PR DESCRIPTION
Address issue #86.  PR is against `hydro-devel` (I need it in hydro), let me know if you want me to issue a PR against `indigo-devel` as well.

This PR is required for floating joint support in the `robot_state_publisher` (see ros/robot_state_publisher#19)
