### PR TITLE
warn when joints have no limits

### DIFF
--- a/joint_state_publisher/joint_state_publisher/joint_state_publisher
+++ b/joint_state_publisher/joint_state_publisher/joint_state_publisher
@@ -54,6 +54,7 @@ class JointStatePublisher():
                         minval = float(limit.getAttribute('lower'))
                         maxval = float(limit.getAttribute('upper'))
                     except:
+                        rospy.logwarn("%s is not fixed, nor continuous, but limits are not specified!" % name)
                         continue
 
                 safety_tags = child.getElementsByTagName('safety_controller')


### PR DESCRIPTION
This adds a simple warning to let you know your URDF has joints that are not continuous, not fixed, and has no limits. When this is the case (which, easily happens when exporting URDFs from Solidworks), the joint is not added, and eventually you hit this awesome traceback:

```
Exception in thread Thread-5:
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 810, in __bootstrap_inner
    self.run()
  File "/usr/lib/python2.7/threading.py", line 763, in run
    self.__target(*self.__args, **self.__kwargs)
  File "/home/fergs/fys/src/robot_model/joint_state_publisher/joint_state_publisher/joint_state_publisher", line 203, in loop
    if has_position and 'position' in joint:
TypeError: argument of type 'NoneType' is not iterable
```

Adding the warning at least makes this more easily debuggable.
