### PR TITLE
Add ignored_joints param to joint_state_publisher

### DIFF
--- a/joint_state_publisher/joint_state_publisher/joint_state_publisher
+++ b/joint_state_publisher/joint_state_publisher/joint_state_publisher
@@ -27,6 +27,7 @@ class JointStatePublisher():
         self.free_joints = {}
         self.joint_list = [] # for maintaining the original order of the joints
         self.dependent_joints = get_param("dependent_joints", {})
+        self.ignored_joints = get_param("ignored_joints", {})
         use_mimic = get_param('use_mimic_tags', True)
         use_small = get_param('use_smallest_joint_limits', True)
 
@@ -45,6 +46,8 @@ class JointStatePublisher():
                 if jtype == 'fixed' or jtype == 'floating':
                     continue
                 name = child.getAttribute('name')
+                if name in self.ignored_joints:
+                    continue
                 self.joint_list.append(name)
                 if jtype == 'continuous':
                     minval = -pi


### PR DESCRIPTION
Useful for running joint_state_publisher to provide JointState information for a subset of joints.
