### PR TITLE
revert #108, #106, #105

### DIFF
--- a/collada_urdf/CMakeLists.txt
+++ b/collada_urdf/CMakeLists.txt
@@ -44,12 +44,6 @@ endif()
 find_package(Boost REQUIRED COMPONENTS system filesystem program_options)
 include_directories(${Boost_INCLUDE_DIR})
 
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(PCRECPP libpcrecpp)
-if( PCRECPP_FOUND )
-  include_directories(${PCRECPP_INCLUDE_DIRS})
-  link_directories(${PCRECPP_LIBRARY_DIRS})
-endif()
 find_package(COLLADA_DOM 2.3 COMPONENTS 1.5)
 if( COLLADA_DOM_FOUND )
   include_directories(${COLLADA_DOM_INCLUDE_DIRS})
@@ -60,17 +54,17 @@ include_directories(${TinyXML_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
 link_directories(${catkin_LIBRARY_DIRS})
 
 add_library(${PROJECT_NAME} src/collada_urdf.cpp)
-target_link_libraries(${PROJECT_NAME} ${TinyXML_LIBRARIES} ${catkin_LIBRARIES} ${PCRECPP_LIBRARIES} ${COLLADA_DOM_LIBRARIES}
+target_link_libraries(${PROJECT_NAME} ${TinyXML_LIBRARIES} ${catkin_LIBRARIES} ${COLLADA_DOM_LIBRARIES}  
   ${Boost_LIBRARIES} ${ASSIMP_LIBRARIES})
 set_target_properties(${PROJECT_NAME} PROPERTIES COMPILER_FLAGS "${ASSIMP_CXX_FLAGS} ${ASSIMP_CFLAGS_OTHER}")
 set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "${ASSIMP_LINK_FLAGS}") 
 
 add_executable(urdf_to_collada src/urdf_to_collada.cpp)
-target_link_libraries(urdf_to_collada ${catkin_LIBRARIES} ${PCRECPP_LIBRARIES} ${COLLADA_DOM_LIBRARIES}
+target_link_libraries(urdf_to_collada ${catkin_LIBRARIES} ${COLLADA_DOM_LIBRARIES}  
   ${Boost_LIBRARIES} ${PROJECT_NAME})
 
 add_executable(collada_to_urdf src/collada_to_urdf.cpp)
-target_link_libraries(collada_to_urdf ${ASSIMP_LIBRARIES} ${catkin_LIBRARIES} ${PCRECPP_LIBRARIES} ${COLLADA_DOM_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(collada_to_urdf ${ASSIMP_LIBRARIES} ${catkin_LIBRARIES} ${COLLADA_DOM_LIBRARIES} ${Boost_LIBRARIES})
 set_target_properties(collada_to_urdf PROPERTIES COMPILER_FLAGS "${ASSIMP_CXX_FLAGS} ${ASSIMP_CFLAGS_OTHER}")
 set_target_properties(collada_to_urdf PROPERTIES LINK_FLAGS "${ASSIMP_LINK_FLAGS}")
 

--- a/collada_urdf/package.xml
+++ b/collada_urdf/package.xml
@@ -25,7 +25,6 @@
   <build_depend>collada_parser</build_depend>
   <build_depend>liburdfdom-dev</build_depend>
   <build_depend>liburdfdom-headers-dev</build_depend>
-  <build_depend>pcre-dev</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>urdf</build_depend>
   <build_depend>geometric_shapes</build_depend>
@@ -39,7 +38,6 @@
   <run_depend>liburdfdom-dev</run_depend>
   <run_depend>liburdfdom-headers-dev</run_depend>
   <run_depend>resource_retriever</run_depend>
-  <run_depend>pcre</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>urdf</run_depend>
   <run_depend>tf</run_depend>

--- a/collada_urdf/src/urdf_to_collada.cpp
+++ b/collada_urdf/src/urdf_to_collada.cpp
@@ -37,9 +37,6 @@
 #include "collada_urdf/collada_urdf.h"
 #include <ros/ros.h>
 
-#include <pcrecpp.h>
-pcrecpp::RE __re__(""); // https://github.com/ros/robot_model/issues/89
-
 int main(int argc, char** argv)
 {
     if (argc != 3) {

--- a/urdf/CMakeLists.txt
+++ b/urdf/CMakeLists.txt
@@ -15,9 +15,9 @@ pkg_check_modules(libpcrecpp libpcrecpp)
 
 catkin_package(
   LIBRARIES ${PROJECT_NAME}
-  INCLUDE_DIRS include
+  INCLUDE_DIRS include ${TinyXML_INLCLUDE_DIRS}
   CATKIN_DEPENDS rosconsole_bridge roscpp
-  DEPENDS urdfdom_headers urdfdom TinyXML
+  DEPENDS urdfdom_headers urdfdom Boost pcrecpp
 )
 
 include_directories(SYSTEM ${Boost_INCLUDE_DIR})
@@ -33,7 +33,7 @@ include_directories(
 link_directories(${catkin_LIBRARY_DIRS})
 
 add_library(${PROJECT_NAME} src/model.cpp src/rosconsole_bridge.cpp)
-target_link_libraries(${PROJECT_NAME} ${libpcrecpp_LIBRARIES} ${TinyXML_LIBRARIES} ${catkin_LIBRARIES} ${urdfdom_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${TinyXML_LIBRARIES} ${catkin_LIBRARIES} ${urdfdom_LIBRARIES})
 
 if(APPLE)
   set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")

--- a/urdf/package.xml
+++ b/urdf/package.xml
@@ -23,7 +23,6 @@
   <build_depend>liburdfdom-headers-dev</build_depend>
   <build_depend>rosconsole_bridge</build_depend>
   <build_depend>roscpp</build_depend>
-  <build_depend>pcre-dev</build_depend>
   <build_depend>urdf_parser_plugin</build_depend>
   <build_depend>pluginlib</build_depend>
   <build_depend>cmake_modules</build_depend>
@@ -33,7 +32,6 @@
   <run_depend>liburdfdom-headers-dev</run_depend>
   <run_depend>rosconsole_bridge</run_depend>
   <run_depend>roscpp</run_depend>
-  <run_depend>pcre</run_depend>
   <run_depend>urdf_parser_plugin</run_depend>
   <run_depend>pluginlib</run_depend>
 

--- a/urdf/src/model.cpp
+++ b/urdf/src/model.cpp
@@ -52,9 +52,6 @@
 #include <fstream>
 #include <iostream>
 
-#include <pcrecpp.h>
-pcrecpp::RE __re__("");
-
 namespace urdf{
 
 static bool IsColladaData(const std::string& data)


### PR DESCRIPTION
all pcre hack is not necessary once new version of collada is released, (https://github.com/rdiankov/collada-dom/issues/16)

this will solve double free corruption problem #112 
