### PR TITLE
Add travis configuration file and fix kdl_parser_py package.xml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,39 @@
+sudo: required
+dist: trusty
+# Force travis to use its minimal image with default Python settings
+language: generic
+compiler:
+  - gcc
+env:
+  global:
+    - CATKIN_WS=~/catkin_ws
+    - CATKIN_WS_SRC=${CATKIN_WS}/src
+  matrix:
+    - CI_ROS_DISTRO="indigo"
+    - CI_ROS_DISTRO="jade"
+install:
+  - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu trusty main" > /etc/apt/sources.list.d/ros-latest.list'
+  - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq -y python-rosdep python-catkin-tools
+  - sudo rosdep init
+  - rosdep update
+  # Use rosdep to install all dependencies (including ROS itself)
+  - rosdep install --from-paths ./ -i -y --rosdistro $CI_ROS_DISTRO
+script:
+  - source /opt/ros/$CI_ROS_DISTRO/setup.bash
+  - mkdir -p $CATKIN_WS_SRC
+  - ln -s $TRAVIS_BUILD_DIR $CATKIN_WS_SRC
+  - cd $CATKIN_WS
+  - catkin init
+  # Enable install space
+  #- catkin config --install
+  # Build [and Install] packages
+  - catkin build --limit-status-rate 0.1 --no-notify -DCMAKE_BUILD_TYPE=Release
+  # Build tests
+  - catkin build --limit-status-rate 0.1 --no-notify --make-args tests
+  # Run tests
+  - catkin run_tests
+  # catkin run_tests always returns 0, use catkin_test_results to check for errors
+  # https://github.com/catkin/catkin_tools/issues/245
+  - catkin_test_results

--- a/kdl_parser_py/package.xml
+++ b/kdl_parser_py/package.xml
@@ -25,6 +25,7 @@
 
   <run_depend version_gte="1.3.0">orocos_kdl</run_depend>
   <run_depend>urdf</run_depend>
+  <run_depend>urdfdom_py</run_depend>
   <run_depend>python_orocos_kdl</run_depend>
 
 </package>


### PR DESCRIPTION
I've added a travis configuration file adapted from [bebop_autonomy](https://github.com/AutonomyLab/bebop_autonomy/blob/indigo-devel/.travis.yml). It found a [test failure](https://travis-ci.org/scpeters/robot_model/builds/96337231) due to a missing `run_depend` in `kdl_parser_py` that I fixed in 92de8a7.
