### PR TITLE
mutable robot_description in URDF with Trigger srv

### DIFF
--- a/urdf/CMakeLists.txt
+++ b/urdf/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(urdf)
 
+if(NOT WIN32)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra")
+endif()
+
 find_package(Boost REQUIRED thread)
 find_package(urdfdom REQUIRED)
 find_package(urdfdom_headers REQUIRED)
@@ -43,12 +47,14 @@ if(CATKIN_ENABLE_TESTING)
   find_package(catkin REQUIRED COMPONENTS rostest)
   add_rostest_gtest(test_urdf_parser test/test_robot_model_parser.launch test/test_robot_model_parser.cpp)
   target_link_libraries(test_urdf_parser ${PROJECT_NAME})
+
+  add_rostest_gtest(test_reload_robot_model
+                   test/test_reload_robot_model.launch
+                   test/test_reload_robot_model.cpp)
+  target_link_libraries(test_reload_robot_model ${PROJECT_NAME})
 endif()
 
-# no idea how CATKIN does this
-# rosbuild_add_rostest(${PROJECT_SOURCE_DIR}/test/test_robot_model_parser.launch)
-
-install(TARGETS ${PROJECT_NAME} 
+install(TARGETS ${PROJECT_NAME}
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})

--- a/urdf/CMakeLists.txt
+++ b/urdf/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(Boost REQUIRED thread)
 find_package(urdfdom REQUIRED)
 find_package(urdfdom_headers REQUIRED)
 find_package(catkin REQUIRED COMPONENTS
-  urdf_parser_plugin pluginlib rosconsole_bridge roscpp cmake_modules)
+  urdf_parser_plugin pluginlib rosconsole_bridge roscpp cmake_modules std_srvs)
 
 
 find_package(TinyXML REQUIRED)

--- a/urdf/include/urdf/model.h
+++ b/urdf/include/urdf/model.h
@@ -42,6 +42,7 @@
 #include <urdf_model/model.h>
 #include <tinyxml.h>
 
+#include <ros/ros.h>
 #include <std_srvs/Trigger.h>
 
 namespace urdf{
@@ -63,8 +64,7 @@ public:
 protected:
   bool loadFromParameterServer(const std::string & param);
   bool reloadModelCallback(std_srvs::Trigger::Request& req, std_srvs::Trigger::Response& res);
-
-  // TODO need a mutex in ModelInterface to protect in-memory representation
+  ros::ServiceServer reload_model_server_;
 };
 
 }

--- a/urdf/include/urdf/model.h
+++ b/urdf/include/urdf/model.h
@@ -42,6 +42,8 @@
 #include <urdf_model/model.h>
 #include <tinyxml.h>
 
+#include <std_srvs/Trigger.h>
+
 namespace urdf{
 
 class Model: public ModelInterface
@@ -55,8 +57,14 @@ public:
   bool initFile(const std::string& filename);
   /// \brief Load Model given the name of a parameter on the parameter server
   bool initParam(const std::string& param);
+  bool initParam(const std::string& param, bool reload_robot_model);
   /// \brief Load Model from a XML-string
   bool initString(const std::string& xmlstring);
+protected:
+  bool loadFromParameterServer(const std::string & param);
+  bool reloadModelCallback(std_srvs::Trigger::Request& req, std_srvs::Trigger::Response& res);
+
+  // TODO need a mutex in ModelInterface to protect in-memory representation
 };
 
 }

--- a/urdf/package.xml
+++ b/urdf/package.xml
@@ -28,6 +28,7 @@
   <build_depend>pluginlib</build_depend>
   <build_depend>cmake_modules</build_depend>
   <build_depend>rostest</build_depend>
+  <build_depend>std_srvs</build_depend>
 
   <run_depend>liburdfdom-dev</run_depend>
   <run_depend>liburdfdom-headers-dev</run_depend>

--- a/urdf/src/model.cpp
+++ b/urdf/src/model.cpp
@@ -36,8 +36,6 @@
 
 #include "urdf/model.h"
 
-#include <ros/ros.h>
-
 /* we include the default parser for plain URDF files; 
    other parsers are loaded via plugins (if available) */
 #include <urdf_parser/urdf_parser.h>
@@ -62,7 +60,6 @@ static bool IsColladaData(const std::string& data)
 
 bool Model::initFile(const std::string& filename)
 {
-
   // get the entire file
   std::string xml_string;
   std::fstream xml_file(filename.c_str(), std::fstream::in);
@@ -111,8 +108,7 @@ bool Model::initParam(const std::string& param, bool reload_robot_model)
   ros::NodeHandle nh;
   if (reload_robot_model) {
     // Advertise the trigger service
-    // TODO save service pointer
-    ros::ServiceServer server = nh.advertiseService(
+    reload_model_server_ = nh.advertiseService(
       "/reload_robot_model", &Model::reloadModelCallback, this);
   }
   return Model::loadFromParameterServer(param);
@@ -199,10 +195,10 @@ bool Model::initString(const std::string& xml_string)
 }
 
 bool Model::reloadModelCallback(
-  std_srvs::Trigger::Request& request,
+  std_srvs::Trigger::Request& /* request */,
   std_srvs::Trigger::Response& response)
 {
-  // TODO Bind parameter name to this class
+  // TODO Bind parameter key ("robot_description") to this class
   response.success = Model::loadFromParameterServer("robot_description");
   return response.success;
 }

--- a/urdf/test/one_link.urdf
+++ b/urdf/test/one_link.urdf
@@ -1,4 +1,4 @@
-<?xml verison="1.0"?>
+<?xml version="1.0"?>
 <robot name="one_link">
   <link name="link1">
     <inertial>

--- a/urdf/test/test_reload_robot_model.cpp
+++ b/urdf/test/test_reload_robot_model.cpp
@@ -51,24 +51,31 @@ TEST(TestURDF, reload_robot_model)
   urdf::Model model;
   // Initialize the model with reload_robot_model set as true
   ASSERT_TRUE(model.initParam(parameter_key, true));
+  ros::spinOnce();
   EXPECT_EQ(model.name_, "r2d2");
   EXPECT_EQ(model.links_.size(), 17);
+  ROS_DEBUG("Initialized model");
 
   ros::NodeHandle node_handle;
   auto reload_model_client = node_handle.serviceClient<std_srvs::Trigger>("/reload_robot_model");
+  ROS_DEBUG("Initialized client");
 
-  // read text from new_robot_dscription a
+  // read text from new_robot_description
   ASSERT_TRUE(node_handle.hasParam(new_parameter_key));
   std::string new_urdf;
   node_handle.getParam(new_parameter_key, new_urdf);
   ASSERT_TRUE(node_handle.hasParam(parameter_key));
   node_handle.setParam(parameter_key, new_urdf);
+  ROS_DEBUG("Got and set params");
 
   std_srvs::Trigger::Request req;
   std_srvs::Trigger::Response res;
 
   // may have to wait a second for the parameter server to get the update?
+  ASSERT_TRUE(ros::service::waitForService("/reload_robot_model", 1000));
+  ROS_DEBUG("waited for service");
   ASSERT_TRUE(reload_model_client.call(req, res));
+  ROS_DEBUG("client call successful");
 
   // Check the new model representation
   EXPECT_EQ(model.name_, "one_link");

--- a/urdf/test/test_reload_robot_model.cpp
+++ b/urdf/test/test_reload_robot_model.cpp
@@ -72,12 +72,9 @@ TEST(TestURDF, reload_robot_model)
   std_srvs::Trigger::Request req;
   std_srvs::Trigger::Response res;
 
-  // may have to wait a second for the parameter server to get the update?
-
   spinner.start();
   ASSERT_TRUE(ros::service::waitForService("/reload_robot_model", 1000));
   ROS_INFO("waited for service");
-  //ros::spinOnce();
   ASSERT_TRUE(reload_model_client.call(req, res));
   ROS_INFO("client call successful");
 

--- a/urdf/test/test_reload_robot_model.cpp
+++ b/urdf/test/test_reload_robot_model.cpp
@@ -1,0 +1,95 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2016, Open Source Robotics Foundation, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "urdf/model.h"
+
+const std::string parameter_key = "robot_description";
+const std::string new_parameter_key = "new_robot_description";
+
+/* Simple case: Initialize a robot model and a robot_description parameter
+ * Publish a new robot_description parameter
+ * send request/publish to latched topic
+ * Expect to see the change in the in-memory representation of the model
+ */
+TEST(TestURDF, reload_robot_model)
+{
+  urdf::Model model;
+  // Initialize the model with reload_robot_model set as true
+  ASSERT_TRUE(model.initParam(parameter_key, true));
+  EXPECT_EQ(model.name_, "r2d2");
+  EXPECT_EQ(model.links_.size(), 17);
+
+  ros::NodeHandle node_handle;
+  auto reload_model_client = node_handle.serviceClient<std_srvs::Trigger>("/reload_robot_model");
+
+  // read text from new_robot_dscription a
+  ASSERT_TRUE(node_handle.hasParam(new_parameter_key));
+  std::string new_urdf;
+  node_handle.getParam(new_parameter_key, new_urdf);
+  ASSERT_TRUE(node_handle.hasParam(parameter_key));
+  node_handle.setParam(parameter_key, new_urdf);
+
+  std_srvs::Trigger::Request req;
+  std_srvs::Trigger::Response res;
+
+  // may have to wait a second for the parameter server to get the update?
+  ASSERT_TRUE(reload_model_client.call(req, res));
+
+  // Check the new model representation
+  EXPECT_EQ(model.name_, "one_link");
+  EXPECT_EQ(model.links_.size(), 1);
+}
+
+
+/* Multithreaded case
+ * Lock model accesses
+ */
+
+
+/* It's important to keep in mind that changes to the urdf::Model DO NOT affect the
+ * robot_description parameter, and changes to the parameter will only affect the Model
+ * when reload_robot_model service is manually triggered.
+ */
+
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "test_mutable_robot_description");
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/urdf/test/test_reload_robot_model.launch
+++ b/urdf/test/test_reload_robot_model.launch
@@ -5,5 +5,5 @@
   <!-- args: path, urdf file, robot name, root name, #joints, #links-->
   <test test-name="test_reload_robot_model"
         pkg="urdf"
-        type="test_reload_robot_model" />
+        type="test_reload_robot_model"/>
 </launch>

--- a/urdf/test/test_reload_robot_model.launch
+++ b/urdf/test/test_reload_robot_model.launch
@@ -1,10 +1,9 @@
 <launch>
   <param name="robot_description" textfile="$(find urdf)/test/test_robot.urdf" />
-  <param name="new_robot_description" textfile="$(find urdf)/test/test_one_link.urdf" />
+  <param name="new_robot_description" textfile="$(find urdf)/test/one_link.urdf" />
   <!-- not sure if we need args -->
   <!-- args: path, urdf file, robot name, root name, #joints, #links-->
-  <test test-name="reload_robot_model_test"
+  <test test-name="test_reload_robot_model"
         pkg="urdf"
-        type="test_reload_robot_model"
-        args="$(find urdf) test_robot.urdf r2d2 dummy_link 16 17" />
+        type="test_reload_robot_model" />
 </launch>

--- a/urdf/test/test_reload_robot_model.launch
+++ b/urdf/test/test_reload_robot_model.launch
@@ -1,0 +1,10 @@
+<launch>
+  <param name="robot_description" textfile="$(find urdf)/test/test_robot.urdf" />
+  <param name="new_robot_description" textfile="$(find urdf)/test/test_one_link.urdf" />
+  <!-- not sure if we need args -->
+  <!-- args: path, urdf file, robot name, root name, #joints, #links-->
+  <test test-name="reload_robot_model_test"
+        pkg="urdf"
+        type="test_reload_robot_model"
+        args="$(find urdf) test_robot.urdf r2d2 dummy_link 16 17" />
+</launch>

--- a/urdf/test/test_robot_model_parser.cpp
+++ b/urdf/test/test_robot_model_parser.cpp
@@ -143,7 +143,7 @@ TEST_F(TestParser, test)
 
   EXPECT_EQ(robot.getName(), robot_name);
   boost::shared_ptr<const urdf::Link> root = robot.getRoot();
-  ASSERT_TRUE(root);
+  ASSERT_TRUE(root != nullptr);
   EXPECT_EQ(root->name, root_name);
 
   ASSERT_TRUE(checkModel(robot));


### PR DESCRIPTION
Current issues:
- [ ] Synchronization.
  - Currently, `Model::initString` (which is called by the `reloadModelCallback`) provides its own mutexes.
  - A truly thread-safe implementation would require adding synchronization to the accessors/mutators in `urdf::ModelInterface`, which is defined in urdfdom_headers. However, changing urdfdom_headers requires waiting on another Ubuntu release cycle (I think it's too late to get major changes into Ubuntu X).
  - A potentially messy and bothersome to use solution: `urdf::Model` could expose a public mutex which user code can lock on before accessing `ModelInterface` functions, and `initString` could lock on that mutex.
- [ ] Tests/examples.
  - I might add tests in robot_state_publisher and even further downstream packages such as MoveIt or ros_controls
- [ ] Performance.
  - Currently the reloadModelCallback reloads the entire robot_description from the parameter server, which is pretty much the most expensive way to do it.
  - Will write tests and do a bit of profiling to see if it's necessary to optimize further.
- [ ] May want to implement a custom service type for the trigger service. A service is a good idea because the client can block until the response comes in (after the model has been changed).
  - See below discussion about message format and pub/sub should be used instead
- [ ] currently "robot_description" parameter key is hardcoded. Should bind the `param` string input from `initParam` to the reloadModelCallback.
