### PR TITLE
Migrate qt

### DIFF
--- a/joint_state_publisher/joint_state_publisher/joint_state_publisher
+++ b/joint_state_publisher/joint_state_publisher/joint_state_publisher
@@ -286,7 +286,7 @@ class JointStatePublisherGui(QWidget):
             self.joint_map[name] = {'slidervalue': 0, 'display': display,
                                     'slider': slider, 'joint': joint}
             # Connect to the signal provided by QSignal
-            slider.valueChanged.connect(self.sliderUpdate)
+            slider.sliderMoved.connect(self.sliderUpdate)
 
         # Synchronize slider and displayed value
         self.sliderUpdate(None)
@@ -320,6 +320,7 @@ class JointStatePublisherGui(QWidget):
                                                            joint)
             joint_info['slider'].setValue(joint_info['slidervalue'])
             joint_info['display'].setText("%.2f" % joint['position'])
+
 
     def center_event(self, event):
         self.center()

--- a/joint_state_publisher/joint_state_publisher/joint_state_publisher
+++ b/joint_state_publisher/joint_state_publisher/joint_state_publisher
@@ -283,12 +283,12 @@ class JointStatePublisherGui(QWidget):
             slider.setValue(RANGE/2)
 
             joint_layout.addWidget(slider)
-            # Connect to the Slider signal
 
             box_layout.addLayout(joint_layout)
 
             self.joint_map[name] = {'slidervalue':0, 'display':display,
                                     'slider':slider, 'joint':joint}
+            # Connect to the signal provided by QSignal
             slider.valueChanged.connect(self.sliderUpdate)
 
         # Synchronize slider and displayed value

--- a/joint_state_publisher/joint_state_publisher/joint_state_publisher
+++ b/joint_state_publisher/joint_state_publisher/joint_state_publisher
@@ -2,8 +2,8 @@
 
 import rospy
 import random
-#import wx
-#import wx.lib.newevent
+
+from python_qt_binding.QtCore import Signal
 from python_qt_binding.QtCore import Qt
 from python_qt_binding.QtGui import QTextOption
 from python_qt_binding.QtGui import QFont
@@ -159,9 +159,8 @@ class JointStatePublisher():
                 joint['effort'] = effort
 
         if self.gui is not None:
-            # post an event here instead of directly calling the update_sliders method, to switch to the wx thread
-            # wx.PostEvent(self.gui.GetEventHandler(), self.gui.UpdateSlidersEvent())
-            qt
+            # signal instead of directly calling the update_sliders method, to switch to the QThread
+            self.gui.sliderUpdateTrigger.emit()
             pass
 
 
@@ -245,6 +244,8 @@ class JointStatePublisher():
                     joint['forward'] = not forward
 
 class JointStatePublisherGui(QWidget):
+    sliderUpdateTrigger = Signal()
+
     def __init__(self, title, jsp):
         super(JointStatePublisherGui, self).__init__()
         self.jsp = jsp
@@ -270,7 +271,6 @@ class JointStatePublisherGui(QWidget):
             display = QLineEdit("0.00")
             display.setAlignment(Qt.AlignRight)
             display.setFont(font)
-            # TODO Add ability to input joint value
             display.setReadOnly(True)
             row_layout.addWidget(display)
 
@@ -291,9 +291,11 @@ class JointStatePublisherGui(QWidget):
                                     'slider':slider, 'joint':joint}
             slider.valueChanged.connect(self.sliderUpdate)
 
+        # Synchronize slider and displayed value
         self.sliderUpdate(None)
-        # self.UpdateSlidersEvent, self.EVT_UPDATESLIDERS = wx.lib.newevent.NewEvent()
-        # self.Bind(self.EVT_UPDATESLIDERS, self.updateSliders)
+
+        # Set up a signal for updating the sliders based on external joint info
+        self.sliderUpdateTrigger.connect(self.updateSliders)
 
         ### Buttons ###
         self.randbutton = QPushButton('Randomize', self)
@@ -302,10 +304,6 @@ class JointStatePublisherGui(QWidget):
         self.ctrbutton = QPushButton('Center', self)
         self.ctrbutton.clicked.connect(self.center_event)
         box_layout.addWidget(self.ctrbutton)
-
-        # wx.EVT_BUTTON(self, 1, self.randomize_event)
-        #wx.EVT_BUTTON(self, 2, self.center_event)
-
 
 
     def update_values(self):
@@ -369,7 +367,6 @@ if __name__ == '__main__':
         if jsp.gui is None:
             jsp.loop()
         else:
-            # qthread? Argh
             Thread(target=jsp.loop).start()
             jsp.app.exec_()
 

--- a/joint_state_publisher/joint_state_publisher/joint_state_publisher
+++ b/joint_state_publisher/joint_state_publisher/joint_state_publisher
@@ -2,12 +2,26 @@
 
 import rospy
 import random
-import wx
-import wx.lib.newevent
+#import wx
+#import wx.lib.newevent
+from python_qt_binding.QtCore import Qt
+from python_qt_binding.QtGui import QTextOption
+from python_qt_binding.QtGui import QFont
+from python_qt_binding.QtWidgets import QApplication
+from python_qt_binding.QtWidgets import QPushButton
+from python_qt_binding.QtWidgets import QHBoxLayout
+from python_qt_binding.QtWidgets import QLabel
+from python_qt_binding.QtWidgets import QSlider
+from python_qt_binding.QtWidgets import QLineEdit
+from python_qt_binding.QtWidgets import QVBoxLayout
+from python_qt_binding.QtWidgets import QSlider
+from python_qt_binding.QtWidgets import QWidget
+
 import xml.dom.minidom
 from sensor_msgs.msg import JointState
 from math import pi
 from threading import Thread
+from sys import argv
 
 RANGE = 10000
 
@@ -104,9 +118,9 @@ class JointStatePublisher():
         use_gui = get_param("use_gui", False)
 
         if use_gui:
-            self.app = wx.App()
+            self.app = QApplication(argv)
             self.gui = JointStatePublisherGui("Joint State Publisher", self)
-            self.gui.Show()
+            self.gui.show()
         else:
             self.gui = None
 
@@ -146,7 +160,9 @@ class JointStatePublisher():
 
         if self.gui is not None:
             # post an event here instead of directly calling the update_sliders method, to switch to the wx thread
-            wx.PostEvent(self.gui.GetEventHandler(), self.gui.UpdateSlidersEvent())
+            # wx.PostEvent(self.gui.GetEventHandler(), self.gui.UpdateSlidersEvent())
+            qt
+            pass
 
 
     def loop(self):
@@ -228,14 +244,13 @@ class JointStatePublisher():
                     joint['position'] = joint['min']
                     joint['forward'] = not forward
 
-class JointStatePublisherGui(wx.Frame):
+class JointStatePublisherGui(QWidget):
     def __init__(self, title, jsp):
-        wx.Frame.__init__(self, None, -1, title, (-1, -1));
+        super(JointStatePublisherGui, self).__init__()
         self.jsp = jsp
         self.joint_map = {}
-        panel = wx.Panel(self, wx.ID_ANY);
-        box = wx.BoxSizer(wx.VERTICAL)
-        font = wx.Font(9, wx.SWISS, wx.NORMAL, wx.BOLD)
+        box_layout = QVBoxLayout(self)
+        font = QFont("Helvetica", 9, QFont.Bold)
 
         ### Sliders ###
         for name in self.jsp.joint_list:
@@ -246,42 +261,51 @@ class JointStatePublisherGui(wx.Frame):
             if joint['min'] == joint['max']:
                 continue
 
-            row = wx.GridSizer(1,2)
-            label = wx.StaticText(panel, -1, name)
-            label.SetFont(font)
-            row.Add(label, 1, wx.ALIGN_CENTER_VERTICAL)
+            joint_layout = QVBoxLayout()
+            row_layout = QHBoxLayout()
 
-            display = wx.TextCtrl (panel, value=str(0),
-                        style=wx.TE_READONLY | wx.ALIGN_RIGHT)
+            label = QLabel(name)
+            label.setFont(font)
+            row_layout.addWidget(label)
+            display = QLineEdit("0.00")
+            display.setAlignment(Qt.AlignRight)
+            display.setFont(font)
+            # TODO Add ability to input joint value
+            display.setReadOnly(True)
+            row_layout.addWidget(display)
 
-            row.Add(display, flag= wx.ALIGN_RIGHT| wx.ALIGN_CENTER_VERTICAL)
-            box.Add(row, 1, wx.EXPAND)
-            slider = wx.Slider(panel, -1, RANGE/2, 0, RANGE,
-                        style= wx.SL_AUTOTICKS | wx.SL_HORIZONTAL)
-            slider.SetFont(font)
-            box.Add(slider, 1, wx.EXPAND)
+            joint_layout.addLayout(row_layout)
+
+            slider = QSlider(Qt.Horizontal)
+            
+            slider.setFont(font)
+            slider.setRange(0, RANGE)
+            slider.setValue(RANGE/2)
+
+            joint_layout.addWidget(slider)
+            # Connect to the Slider signal
+
+            box_layout.addLayout(joint_layout)
 
             self.joint_map[name] = {'slidervalue':0, 'display':display,
                                     'slider':slider, 'joint':joint}
+            slider.valueChanged.connect(self.sliderUpdate)
 
-        self.UpdateSlidersEvent, self.EVT_UPDATESLIDERS = wx.lib.newevent.NewEvent()
-        self.Bind(self.EVT_UPDATESLIDERS, self.updateSliders)
+        self.sliderUpdate(None)
+        # self.UpdateSlidersEvent, self.EVT_UPDATESLIDERS = wx.lib.newevent.NewEvent()
+        # self.Bind(self.EVT_UPDATESLIDERS, self.updateSliders)
 
         ### Buttons ###
-        self.randbutton = wx.Button(panel, 1, 'Randomize')
-        self.ctrbutton = wx.Button(panel, 2, 'Center')
-        self.Bind(wx.EVT_SLIDER, self.sliderUpdate)
+        self.randbutton = QPushButton('Randomize', self)
+        self.randbutton.clicked.connect(self.randomize_event)
+        box_layout.addWidget(self.randbutton)
+        self.ctrbutton = QPushButton('Center', self)
+        self.ctrbutton.clicked.connect(self.center_event)
+        box_layout.addWidget(self.ctrbutton)
 
-        wx.EVT_BUTTON(self, 1, self.randomize_event)
-        wx.EVT_BUTTON(self, 2, self.center_event)
+        # wx.EVT_BUTTON(self, 1, self.randomize_event)
+        #wx.EVT_BUTTON(self, 2, self.center_event)
 
-        box.Add(self.randbutton, 0, wx.EXPAND)
-        box.Add(self.ctrbutton, 1, wx.EXPAND)
-
-        panel.SetSizer(box)
-        self.center()
-        box.Fit(self)
-        self.update_values()
 
 
     def update_values(self):
@@ -300,8 +324,8 @@ class JointStatePublisherGui(wx.Frame):
             joint = joint_info['joint']
             joint_info['slidervalue'] = self.valueToSlider(joint['position'],
                                                            joint)
-            joint_info['slider'].SetValue(joint_info['slidervalue'])
-            joint_info['display'].SetValue("%.2f"%joint['position'])
+            joint_info['slider'].setValue(joint_info['slidervalue'])
+            joint_info['display'].setText("%.2f"%joint['position'])
 
     def center_event(self, event):
         self.center()
@@ -326,7 +350,7 @@ class JointStatePublisherGui(wx.Frame):
 
     def sliderUpdate(self, event):
         for (name,joint_info) in self.joint_map.items():
-            joint_info['slidervalue'] = joint_info['slider'].GetValue()
+            joint_info['slidervalue'] = joint_info['slider'].value()
         self.update_values()
 
     def valueToSlider(self, value, joint):
@@ -345,7 +369,8 @@ if __name__ == '__main__':
         if jsp.gui is None:
             jsp.loop()
         else:
+            # qthread? Argh
             Thread(target=jsp.loop).start()
-            jsp.app.MainLoop()
+            jsp.app.exec_()
 
     except rospy.ROSInterruptException: pass

--- a/joint_state_publisher/joint_state_publisher/joint_state_publisher
+++ b/joint_state_publisher/joint_state_publisher/joint_state_publisher
@@ -3,18 +3,16 @@
 import rospy
 import random
 
-from python_qt_binding.QtCore import Signal
 from python_qt_binding.QtCore import Qt
-from python_qt_binding.QtGui import QTextOption
+from python_qt_binding.QtCore import Signal
 from python_qt_binding.QtGui import QFont
 from python_qt_binding.QtWidgets import QApplication
-from python_qt_binding.QtWidgets import QPushButton
 from python_qt_binding.QtWidgets import QHBoxLayout
 from python_qt_binding.QtWidgets import QLabel
-from python_qt_binding.QtWidgets import QSlider
 from python_qt_binding.QtWidgets import QLineEdit
-from python_qt_binding.QtWidgets import QVBoxLayout
+from python_qt_binding.QtWidgets import QPushButton
 from python_qt_binding.QtWidgets import QSlider
+from python_qt_binding.QtWidgets import QVBoxLayout
 from python_qt_binding.QtWidgets import QWidget
 
 import xml.dom.minidom
@@ -25,6 +23,7 @@ from sys import argv
 
 RANGE = 10000
 
+
 def get_param(name, value=None):
     private = "~%s" % name
     if rospy.has_param(private):
@@ -34,12 +33,13 @@ def get_param(name, value=None):
     else:
         return value
 
+
 class JointStatePublisher():
     def __init__(self):
         description = get_param('robot_description')
         robot = xml.dom.minidom.parseString(description).getElementsByTagName('robot')[0]
         self.free_joints = {}
-        self.joint_list = [] # for maintaining the original order of the joints
+        self.joint_list = []  # for maintaining the original order of the joints
         self.dependent_joints = get_param("dependent_joints", {})
         use_mimic = get_param('use_mimic_tags', True)
         use_small = get_param('use_smallest_joint_limits', True)
@@ -73,7 +73,7 @@ class JointStatePublisher():
                         continue
 
                 safety_tags = child.getElementsByTagName('safety_controller')
-                if use_small and len(safety_tags)==1:
+                if use_small and len(safety_tags) == 1:
                     tag = safety_tags[0]
                     if tag.hasAttribute('soft_lower_limit'):
                         minval = max(minval, float(tag.getAttribute('soft_lower_limit')))
@@ -81,7 +81,7 @@ class JointStatePublisher():
                         maxval = min(maxval, float(tag.getAttribute('soft_upper_limit')))
 
                 mimic_tags = child.getElementsByTagName('mimic')
-                if use_mimic and len(mimic_tags)==1:
+                if use_mimic and len(mimic_tags) == 1:
                     tag = mimic_tags[0]
                     entry = {'parent': tag.getAttribute('joint')}
                     if tag.hasAttribute('multiplier'):
@@ -102,7 +102,7 @@ class JointStatePublisher():
                 else:
                     zeroval = 0
 
-                joint = {'min':minval, 'max':maxval, 'zero':zeroval}
+                joint = {'min': minval, 'max': maxval, 'zero': zeroval}
                 if pub_def_positions:
                     joint['position'] = zeroval
                 if pub_def_vels:
@@ -113,7 +113,6 @@ class JointStatePublisher():
                 if jtype == 'continuous':
                     joint['continuous'] = True
                 self.free_joints[name] = joint
-
 
         use_gui = get_param("use_gui", False)
 
@@ -161,11 +160,9 @@ class JointStatePublisher():
         if self.gui is not None:
             # signal instead of directly calling the update_sliders method, to switch to the QThread
             self.gui.sliderUpdateTrigger.emit()
-            pass
-
 
     def loop(self):
-        hz = get_param("rate", 10) # 10hz
+        hz = get_param("rate", 10)  # 10hz
         r = rospy.Rate(hz)
 
         delta = get_param("delta", 0.0)
@@ -182,7 +179,7 @@ class JointStatePublisher():
             has_position = len(self.dependent_joints.items()) > 0
             has_velocity = False
             has_effort = False
-            for (name,joint) in self.free_joints.items():
+            for name, joint in self.free_joints.items():
                 if not has_position and 'position' in joint:
                     has_position = True
                 if not has_velocity and 'velocity' in joint:
@@ -197,7 +194,6 @@ class JointStatePublisher():
                 msg.velocity = num_joints * [0.0]
             if has_effort:
                 msg.effort = num_joints * [0.0]
-
 
             for i, name in enumerate(self.joint_list):
                 msg.name.append(str(name))
@@ -243,6 +239,7 @@ class JointStatePublisher():
                     joint['position'] = joint['min']
                     joint['forward'] = not forward
 
+
 class JointStatePublisherGui(QWidget):
     sliderUpdateTrigger = Signal()
 
@@ -277,7 +274,7 @@ class JointStatePublisherGui(QWidget):
             joint_layout.addLayout(row_layout)
 
             slider = QSlider(Qt.Horizontal)
-            
+
             slider.setFont(font)
             slider.setRange(0, RANGE)
             slider.setValue(RANGE/2)
@@ -286,8 +283,8 @@ class JointStatePublisherGui(QWidget):
 
             box_layout.addLayout(joint_layout)
 
-            self.joint_map[name] = {'slidervalue':0, 'display':display,
-                                    'slider':slider, 'joint':joint}
+            self.joint_map[name] = {'slidervalue': 0, 'display': display,
+                                    'slider': slider, 'joint': joint}
             # Connect to the signal provided by QSignal
             slider.valueChanged.connect(self.sliderUpdate)
 
@@ -305,9 +302,8 @@ class JointStatePublisherGui(QWidget):
         self.ctrbutton.clicked.connect(self.center_event)
         box_layout.addWidget(self.ctrbutton)
 
-
     def update_values(self):
-        for (name,joint_info) in self.joint_map.items():
+        for name, joint_info in self.joint_map.items():
             purevalue = joint_info['slidervalue']
             joint = joint_info['joint']
             value = self.sliderToValue(purevalue, joint)
@@ -318,19 +314,19 @@ class JointStatePublisherGui(QWidget):
         self.update_sliders()
 
     def update_sliders(self):
-        for (name,joint_info) in self.joint_map.items():
+        for name, joint_info in self.joint_map.items():
             joint = joint_info['joint']
             joint_info['slidervalue'] = self.valueToSlider(joint['position'],
                                                            joint)
             joint_info['slider'].setValue(joint_info['slidervalue'])
-            joint_info['display'].setText("%.2f"%joint['position'])
+            joint_info['display'].setText("%.2f" % joint['position'])
 
     def center_event(self, event):
         self.center()
 
     def center(self):
         rospy.loginfo("Centering")
-        for (name,joint_info) in self.joint_map.items():
+        for name, joint_info in self.joint_map.items():
             joint = joint_info['joint']
             joint_info['slidervalue'] = self.valueToSlider(joint['zero'], joint)
         self.update_values()
@@ -340,14 +336,13 @@ class JointStatePublisherGui(QWidget):
 
     def randomize(self):
         rospy.loginfo("Randomizing")
-        for (name,joint_info) in self.joint_map.items():
+        for name, joint_info in self.joint_map.items():
             joint = joint_info['joint']
             joint_info['slidervalue'] = self.valueToSlider(random.uniform(joint['min'], joint['max']), joint)
         self.update_values()
 
-
     def sliderUpdate(self, event):
-        for (name,joint_info) in self.joint_map.items():
+        for name, joint_info in self.joint_map.items():
             joint_info['slidervalue'] = joint_info['slider'].value()
         self.update_values()
 
@@ -370,4 +365,5 @@ if __name__ == '__main__':
             Thread(target=jsp.loop).start()
             jsp.app.exec_()
 
-    except rospy.ROSInterruptException: pass
+    except rospy.ROSInterruptException:
+        pass

--- a/joint_state_publisher/package.xml
+++ b/joint_state_publisher/package.xml
@@ -14,11 +14,11 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>rospy</build_depend>
-  <build_depend>wxpython</build_depend>
+  <build_depend>python_qt_binding</build_depend>
   <build_depend>sensor_msgs</build_depend>
 
   <run_depend>rospy</run_depend>
-  <run_depend>wxpython</run_depend>
+  <run_depend>python_qt_binding</run_depend>
   <run_depend>sensor_msgs</run_depend>
 
 </package>


### PR DESCRIPTION
Fixes #67 by migrating from wxWidgets to qt. I tried to keep the translation faithful and not introduce new behavior or functionality.

This should also fix the many build failures on the Kinetic build farm for joint_state_publisher, so I'd like to get it merged soon.

Can someone who likes Python and Qt give a review? @ros/ros_team, @dlu, @ablasdel or whoever is available...

suggested testing (I could make a launchfile for anyone who's super lazy):

My workflow for this right now is to use shadow-fixed on a Xenial vm and only build the joint_state_publisher package, e.g. with `catkin_make_isolated --only-pkg-with-deps...`. That way the only dependencies I need to bring in are rospy, sensor_msgs. and python_qt_binding. But a few other things are needed for full testing (rosparam, rostopic).

where <urdf> is a valid urdf with one or more non-fixed joints:

```
rosparam set robot_description -t <urdf>
rosrun joint_state_publisher joint_state_publisher 
(in another terminal)
rostopic echo "joint_states"
```

try clicking the buttons, moving the slider, viewing the rostopic output to see that the joint states are consistent, etc.
