### PR TITLE
joint_state_publisher: Change slider update method

### DIFF
--- a/joint_state_publisher/joint_state_publisher/joint_state_publisher
+++ b/joint_state_publisher/joint_state_publisher/joint_state_publisher
@@ -286,7 +286,7 @@ class JointStatePublisherGui(QWidget):
             self.joint_map[name] = {'slidervalue': 0, 'display': display,
                                     'slider': slider, 'joint': joint}
             # Connect to the signal provided by QSignal
-            slider.sliderMoved.connect(self.sliderUpdate)
+            slider.valueChanged.connect(self.sliderUpdate)
 
         # Synchronize slider and displayed value
         self.sliderUpdate(None)


### PR DESCRIPTION
The sliderMoved method is always returning the same value so the sliders are not moving, but valueChanged method is working.
