### PR TITLE
Use signal and sys.exit to fix shutdown in joint_state_publisher

### DIFF
--- a/joint_state_publisher/joint_state_publisher/joint_state_publisher
+++ b/joint_state_publisher/joint_state_publisher/joint_state_publisher
@@ -19,7 +19,8 @@ import xml.dom.minidom
 from sensor_msgs.msg import JointState
 from math import pi
 from threading import Thread
-from sys import argv
+import sys
+import signal
 
 RANGE = 10000
 
@@ -117,7 +118,7 @@ class JointStatePublisher():
         use_gui = get_param("use_gui", False)
 
         if use_gui:
-            self.app = QApplication(argv)
+            self.app = QApplication(sys.argv)
             self.gui = JointStatePublisherGui("Joint State Publisher", self)
             self.gui.show()
         else:
@@ -364,7 +365,8 @@ if __name__ == '__main__':
             jsp.loop()
         else:
             Thread(target=jsp.loop).start()
-            jsp.app.exec_()
+            signal.signal(signal.SIGINT, signal.SIG_DFL)
+            sys.exit(jsp.app.exec_())
 
     except rospy.ROSInterruptException:
         pass


### PR DESCRIPTION
@vincentrou I think this fixes the shutdown problem. Feel free to take a look and test it. If you think it looks good I will close your PR in favor of this one.

(As a side note, I noticed while I was testing this that "Randomize" and "Center" buttons are just broken on Xenial/Qt5. I will take a look at that next.)

The solution is based on this Stack Overflow question:
http://stackoverflow.com/questions/2300401/qapplication-how-to-shutdown-gracefully-on-ctrl-c
