### PR TITLE
compile collada_urdf with c++11 standard

### DIFF
--- a/collada_urdf/CMakeLists.txt
+++ b/collada_urdf/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 2.8.12)
 project(collada_urdf)
 
 find_package(catkin REQUIRED COMPONENTS angles collada_parser resource_retriever urdf geometric_shapes tf cmake_modules)
@@ -9,6 +9,8 @@ catkin_package(
   LIBRARIES ${PROJECT_NAME}
   INCLUDE_DIRS include
   DEPENDS angles collada_parser resource_retriever urdf geometric_shapes tf)
+
+add_compile_options(-std=gnu++11)
 
 include_directories(include)
 


### PR DESCRIPTION
This is required to compile with `geometric_shape`'s c++11 headers.
See http://discourse.ros.org/t/std-shared-ptr-in-the-geometric-shapes-public-api/395/5 for details.

As the gnu-specific keyword "typeof" is used in the code,
the gnu++11 standard has to be specified.

cmake_minimum_required was increased to have add_compile_options around.
