### PR TITLE
Find correct Eigen3

### DIFF
--- a/collada_urdf/CMakeLists.txt
+++ b/collada_urdf/CMakeLists.txt
@@ -5,12 +5,16 @@ find_package(catkin REQUIRED COMPONENTS angles collada_parser resource_retriever
 
 find_package(TinyXML REQUIRED)
 
+find_package(Eigen3 REQUIRED)
+
 catkin_package(
   LIBRARIES ${PROJECT_NAME}
   INCLUDE_DIRS include
-  DEPENDS angles collada_parser resource_retriever urdf geometric_shapes tf)
+  CATKIN_DEPENDS angles collada_parser resource_retriever urdf geometric_shapes tf
+  DEPENDS EIGEN3)
 
 include_directories(include)
+include_directories(${EIGEN3_INCLUDE_DIR})
 
 find_package(assimp QUIET)
 if ( NOT ASSIMP_FOUND )
@@ -54,13 +58,13 @@ include_directories(${TinyXML_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
 link_directories(${catkin_LIBRARY_DIRS})
 
 add_library(${PROJECT_NAME} src/collada_urdf.cpp)
-target_link_libraries(${PROJECT_NAME} ${TinyXML_LIBRARIES} ${catkin_LIBRARIES} ${COLLADA_DOM_LIBRARIES}  
+target_link_libraries(${PROJECT_NAME} ${TinyXML_LIBRARIES} ${catkin_LIBRARIES} ${COLLADA_DOM_LIBRARIES}
   ${Boost_LIBRARIES} ${ASSIMP_LIBRARIES})
 set_target_properties(${PROJECT_NAME} PROPERTIES COMPILER_FLAGS "${ASSIMP_CXX_FLAGS} ${ASSIMP_CFLAGS_OTHER}")
-set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "${ASSIMP_LINK_FLAGS}") 
+set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "${ASSIMP_LINK_FLAGS}")
 
 add_executable(urdf_to_collada src/urdf_to_collada.cpp)
-target_link_libraries(urdf_to_collada ${catkin_LIBRARIES} ${COLLADA_DOM_LIBRARIES}  
+target_link_libraries(urdf_to_collada ${catkin_LIBRARIES} ${COLLADA_DOM_LIBRARIES}
   ${Boost_LIBRARIES} ${PROJECT_NAME})
 
 add_executable(collada_to_urdf src/collada_to_urdf.cpp)
@@ -70,7 +74,7 @@ set_target_properties(collada_to_urdf PROPERTIES LINK_FLAGS "${ASSIMP_LINK_FLAGS
 
 if(CATKIN_ENABLE_TESTING)
   catkin_add_gtest(test_collada_writer test/test_collada_urdf.cpp)
-  target_link_libraries(test_collada_writer ${PROJECT_NAME} ${catkin_LIBRARIES} ${COLLADA_DOM_LIBRARIES}  
+  target_link_libraries(test_collada_writer ${PROJECT_NAME} ${catkin_LIBRARIES} ${COLLADA_DOM_LIBRARIES}
     ${Boost_LIBRARIES})
 endif()
 

--- a/collada_urdf/src/collada_urdf.cpp
+++ b/collada_urdf/src/collada_urdf.cpp
@@ -82,7 +82,7 @@
 #include <geometric_shapes/shapes.h>
 #include <geometric_shapes/mesh_operations.h>
 
-#define FOREACH(it, v) for(typeof((v).begin())it = (v).begin(); it != (v).end(); (it)++)
+#define FOREACH(it, v) for(__typeof__((v).begin())it = (v).begin(); it != (v).end(); (it)++)
 #define FOREACHC FOREACH
 
 using namespace std;
@@ -1428,14 +1428,14 @@ protected:
     }
 
     void _loadVertices(const shapes::Mesh *mesh, domGeometryRef pdomgeom) {
-	
+
 	// convert the mesh into an STL binary (in memory)
 	std::vector<char> buffer;
 	shapes::writeSTLBinary(mesh, buffer);
-	
+
 	// Create an instance of the Importer class
 	Assimp::Importer importer;
-	
+
 	// And have it read the given file with some postprocessing
 	const aiScene* scene = importer.ReadFileFromMemory(reinterpret_cast<const void*>(&buffer[0]), buffer.size(),
 							   aiProcess_Triangulate            |
@@ -1443,8 +1443,8 @@ protected:
 							   aiProcess_SortByPType            |
 							   aiProcess_OptimizeGraph          |
 							   aiProcess_OptimizeMeshes, "stl");
-	
-	// Note: we do this mesh -> STL -> assimp mesh because the aiScene::aiScene symbol is hidden by default 
+
+	// Note: we do this mesh -> STL -> assimp mesh because the aiScene::aiScene symbol is hidden by default
 
             domMeshRef pdommesh = daeSafeCast<domMesh>(pdomgeom->add(COLLADA_ELEMENT_MESH));
             domSourceRef pvertsource = daeSafeCast<domSource>(pdommesh->add(COLLADA_ELEMENT_SOURCE));


### PR DESCRIPTION
My setup has diverged a little from stock so not sure if this is needed, creating a PR regardless.

When looking for headers from `eigen_stl_containers` via `geometric_shapes`, `collada_urdf` would complain about `Eigen/Core` not found. 

Others have worked around similar issue by symlinking `usr/include/eigen3/Eigen` to `/usr/local/include/Eigen`.

https://github.com/ros-planning/moveit_core/issues/150
