### PR TITLE
compile collada_urdf with c++11 standard (redux)

### DIFF
--- a/collada_urdf/CMakeLists.txt
+++ b/collada_urdf/CMakeLists.txt
@@ -10,6 +10,7 @@ catkin_package(
   INCLUDE_DIRS include
   DEPENDS angles collada_parser resource_retriever urdf geometric_shapes tf)
 
+include(CheckCXXCompilerFlag)
 check_cxx_compiler_flag(-std=c++11 HAS_STD_CPP11_FLAG)
 if(HAS_STD_CPP11_FLAG)
   add_compile_options(-std=c++11)

--- a/collada_urdf/CMakeLists.txt
+++ b/collada_urdf/CMakeLists.txt
@@ -10,7 +10,10 @@ catkin_package(
   INCLUDE_DIRS include
   DEPENDS angles collada_parser resource_retriever urdf geometric_shapes tf)
 
-add_compile_options(-std=gnu++11)
+check_cxx_compiler_flag(-std=c++11 HAS_STD_CPP11_FLAG)
+if(HAS_STD_CPP11_FLAG)
+  add_compile_options(-std=c++11)
+endif()
 
 include_directories(include)
 

--- a/collada_urdf/CMakeLists.txt
+++ b/collada_urdf/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 2.8.12)
 project(collada_urdf)
 
 find_package(catkin REQUIRED COMPONENTS angles collada_parser resource_retriever urdf geometric_shapes tf cmake_modules)
@@ -9,6 +9,8 @@ catkin_package(
   LIBRARIES ${PROJECT_NAME}
   INCLUDE_DIRS include
   DEPENDS angles collada_parser resource_retriever urdf geometric_shapes tf)
+
+add_compile_options(-std=gnu++11)
 
 include_directories(include)
 

--- a/collada_urdf/include/collada_urdf/collada_urdf.h
+++ b/collada_urdf/include/collada_urdf/collada_urdf.h
@@ -39,7 +39,14 @@
 
 #include <string>
 #include <boost/shared_ptr.hpp>
+
+#ifndef _WIN32
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #include <dae.h>
+#pragma GCC diagnostic pop
+#endif
+
 #include "urdf/model.h"
 
 namespace collada_urdf {

--- a/collada_urdf/src/collada_urdf.cpp
+++ b/collada_urdf/src/collada_urdf.cpp
@@ -40,6 +40,9 @@
 #include <vector>
 #include <list>
 
+#ifndef _WIN32
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #include <dae.h>
 #include <dae/daeDocument.h>
 #include <dae/daeErrorHandler.h>
@@ -49,6 +52,9 @@
 #include <dom/domElements.h>
 #include <dom/domTriangles.h>
 #include <dom/domTypes.h>
+#pragma GCC diagnostic pop
+#endif
+
 #include <resource_retriever/retriever.h>
 #include <urdf/model.h>
 #include <urdf_model/pose.h>

--- a/collada_urdf/src/collada_urdf.cpp
+++ b/collada_urdf/src/collada_urdf.cpp
@@ -82,7 +82,7 @@
 #include <geometric_shapes/shapes.h>
 #include <geometric_shapes/mesh_operations.h>
 
-#define FOREACH(it, v) for(typeof((v).begin())it = (v).begin(); it != (v).end(); (it)++)
+#define FOREACH(it, v) for(decltype((v).begin()) it = (v).begin(); it != (v).end(); (it)++)
 #define FOREACHC FOREACH
 
 using namespace std;

--- a/collada_urdf/src/urdf_to_collada.cpp
+++ b/collada_urdf/src/urdf_to_collada.cpp
@@ -34,7 +34,13 @@
 
 /* Author: Tim Field */
 
+#ifndef _WIN32
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #include "collada_urdf/collada_urdf.h"
+#pragma GCC diagnostic pop
+#endif
+
 #include <ros/ros.h>
 
 int main(int argc, char** argv)


### PR DESCRIPTION
This is a small change to https://github.com/ros/robot_model/pull/142 which uses `decltype` (`typeof` recently bit me when doing some stuff on Windows, which doesn't have that) and checking to see if the `-std=` compiler flag is supported before passing it.

I didn't have xenial handy to test it yet, so I'll do that shortly.
