### PR TITLE
Migrated slots in joint state publisher gui to Qt5

### DIFF
--- a/joint_state_publisher/joint_state_publisher/joint_state_publisher
+++ b/joint_state_publisher/joint_state_publisher/joint_state_publisher
@@ -3,6 +3,7 @@
 import rospy
 import random
 
+from python_qt_binding.QtCore import pyqtSlot
 from python_qt_binding.QtCore import Qt
 from python_qt_binding.QtCore import Signal
 from python_qt_binding.QtGui import QFont
@@ -303,6 +304,7 @@ class JointStatePublisherGui(QWidget):
         self.ctrbutton.clicked.connect(self.center_event)
         box_layout.addWidget(self.ctrbutton)
 
+    @pyqtSlot(int)
     def onValueChanged(self, event):
         # A slider value was changed, but we need to change the joint_info metadata.
         for name, joint_info in self.joint_map.items():
@@ -311,7 +313,8 @@ class JointStatePublisherGui(QWidget):
             joint['position'] = self.sliderToValue(joint_info['slidervalue'], joint)
             joint_info['display'].setText("%.2f" % joint['position'])
 
-    def updateSliders(self, event):
+    @pyqtSlot()
+    def updateSliders(self):
         self.update_sliders()
 
     def update_sliders(self):


### PR DESCRIPTION
Removed one argument from the `updateSliders()` slot. It is not needed in Qt5 and actually caused a type error: `TypeError: updateSliders() takes exactly 2 arguments (1 given)`.
