### PR TITLE
Fix initial position of sliders in joint_state_publisher GUI

### DIFF
--- a/joint_state_publisher/joint_state_publisher/joint_state_publisher
+++ b/joint_state_publisher/joint_state_publisher/joint_state_publisher
@@ -289,6 +289,9 @@ class JointStatePublisherGui(QWidget):
             # Connect to the signal provided by QSignal
             slider.valueChanged.connect(self.onValueChanged)
 
+        # Set zero positions read from parameters
+        self.center()
+
         # Synchronize slider and displayed value
         self.sliderUpdate(None)
 


### PR DESCRIPTION
Caused by a regression in 8c6cf9841cb, the slider positions are not initialized correctly at startup
from the zero positions provided to the joint state publisher. This commit fixes the issue, by adding the call to `center()` again that got lost in that commit.
