### PR TITLE
[collada_urdf] Fix being deprecated tag: cfmDamping -> implicitSpringDamper

### DIFF
--- a/collada_urdf/src/collada_to_urdf.cpp
+++ b/collada_urdf/src/collada_to_urdf.cpp
@@ -493,7 +493,7 @@ void addChildJointNamesXML(boost::shared_ptr<const Link> link, ofstream& os)
       os << "  </transmission>" << endl;
 #ifdef GAZEBO_1_3
       os << "  <gazebo reference=\"" << (*child)->parent_joint->name << "\">" << endl;
-      os << "    <cfmDamping>0.4</cfmDamping>" << endl;
+      os << "    <implicitSpringDamper>0.4</implicitSpringDamper>" << endl;
       os << "  </gazebo>" << endl;
 #endif
     }


### PR DESCRIPTION
For deprecation warning on running gazebo.

```
Warning [parser_urdf.cc:1303] Note that cfmDamping is being deprecated by implicitSpringDamper, please replace instances of cfmDamping with implicitSpringDamper in your model.
```
