### PR TITLE
Add smart ptr typedefs

### DIFF
--- a/urdf/include/urdf/model.h
+++ b/urdf/include/urdf/model.h
@@ -41,6 +41,8 @@
 #include <map>
 #include <urdf_model/model.h>
 #include <tinyxml.h>
+#include <boost/shared_ptr.hpp>
+#include <boost/weak_ptr.hpp>
 
 namespace urdf{
 
@@ -58,6 +60,10 @@ public:
   /// \brief Load Model from a XML-string
   bool initString(const std::string& xmlstring);
 };
+
+typedef boost::shared_ptr<Model> ModelSharedPtr;
+typedef boost::shared_ptr<const Model> ModelConstSharedPtr;
+typedef boost::weak_ptr<Model> ModelWeakPtr;
 
 }
 


### PR DESCRIPTION
This adds the common typedefs that already exist for the rest of the classes in the `urdf` namespace.
