### PR TITLE
Fix dependency with catkin 0.7.2

### DIFF
--- a/urdf/CMakeLists.txt
+++ b/urdf/CMakeLists.txt
@@ -10,14 +10,11 @@ find_package(catkin REQUIRED COMPONENTS
 
 find_package(TinyXML REQUIRED)
 
-find_package(PkgConfig)
-pkg_check_modules(libpcrecpp libpcrecpp)
-
 catkin_package(
   LIBRARIES ${PROJECT_NAME}
   INCLUDE_DIRS include ${TinyXML_INLCLUDE_DIRS}
   CATKIN_DEPENDS rosconsole_bridge roscpp
-  DEPENDS urdfdom_headers urdfdom Boost pcrecpp
+  DEPENDS urdfdom_headers urdfdom Boost
 )
 
 include_directories(SYSTEM ${Boost_INCLUDE_DIR})


### PR DESCRIPTION
since https://github.com/ros/catkin/pull/813 catkin checks that the
dependency was actually found.
