### PR TITLE
urdf: Fix compilation of unit test with C++11 

### DIFF
--- a/urdf/test/test_robot_model_parser.cpp
+++ b/urdf/test/test_robot_model_parser.cpp
@@ -143,7 +143,7 @@ TEST_F(TestParser, test)
 
   EXPECT_EQ(robot.getName(), robot_name);
   boost::shared_ptr<const urdf::Link> root = robot.getRoot();
-  ASSERT_TRUE(root);
+  ASSERT_TRUE(static_cast<bool>(root));
   EXPECT_EQ(root->name, root_name);
 
   ASSERT_TRUE(checkModel(robot));


### PR DESCRIPTION
This PR fixes compilation of the urdf unit tests when C++11 support is enabled. Note that GCC6 compiles with `-std=gnu++14` by default, which means this fix is required with GCC6.

C++11 has explicit conversion operators, which `boost::shared_ptr` (and `std::shared_ptr`) use for conversion to boolean when available. As a result it can't be passed to `ASSERT_TRUE(...)` directly, but needs to be explicitly converted.

The explicit cast is backwards compatible with older C++ versions.
