### PR TITLE
provide urdf_compatibility.h to define SharedPtr types

### DIFF
--- a/urdf/CMakeLists.txt
+++ b/urdf/CMakeLists.txt
@@ -12,10 +12,23 @@ find_package(TinyXML REQUIRED)
 
 catkin_package(
   LIBRARIES ${PROJECT_NAME}
-  INCLUDE_DIRS include ${TinyXML_INLCLUDE_DIRS}
+  INCLUDE_DIRS include ${TinyXML_INLCLUDE_DIRS} ${CATKIN_DEVEL_PREFIX}/include
   CATKIN_DEPENDS rosconsole_bridge roscpp
   DEPENDS urdfdom_headers urdfdom Boost
 )
+
+
+### for Wily: maintain compatibility between urdfdom 0.3 and 0.4 (definining SharedPtr types)
+if( "0.4.0" VERSION_GREATER "${urdfdom_headers_VERSION}")
+  set(HAVE_URDFDOM_4 0)
+else()
+  set(HAVE_URDFDOM_4 1)
+endif()
+set(generated_compat_header "${CATKIN_DEVEL_PREFIX}/include/${PROJECT_NAME}/urdfdom_compatibility.h")
+include_directories("${CATKIN_DEVEL_PREFIX}/include")
+configure_file(urdfdom_compatibility.h.in "${generated_compat_header}" @ONLY)
+install(FILES ${generated_compat_header} DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
+
 
 include_directories(
   include

--- a/urdf/CMakeLists.txt
+++ b/urdf/CMakeLists.txt
@@ -10,6 +10,7 @@ find_package(catkin REQUIRED COMPONENTS
 
 find_package(TinyXML REQUIRED)
 
+make_directory(${CATKIN_DEVEL_PREFIX}/include)
 catkin_package(
   LIBRARIES ${PROJECT_NAME}
   INCLUDE_DIRS include ${TinyXML_INLCLUDE_DIRS} ${CATKIN_DEVEL_PREFIX}/include

--- a/urdf/CMakeLists.txt
+++ b/urdf/CMakeLists.txt
@@ -10,24 +10,23 @@ find_package(catkin REQUIRED COMPONENTS
 
 find_package(TinyXML REQUIRED)
 
-make_directory(${CATKIN_DEVEL_PREFIX}/include)
+if("${urdfdom_headers_VERSION}" VERSION_LESS "1.0")
+  # for Wily: maintain compatibility between urdfdom 0.3 and 0.4 (definining SharedPtr types)
+  set(URDFDOM_DECLARE_TYPES 1)
+else()
+  # declare ModelInterface's SharedPtr
+  set(URDFDOM_DECLARE_TYPES 0)
+endif()
+set(generated_compat_header "${CATKIN_DEVEL_PREFIX}/include/${PROJECT_NAME}/urdfdom_compatibility.h")
+include_directories("${CATKIN_DEVEL_PREFIX}/include")
+configure_file(urdfdom_compatibility.h.in "${generated_compat_header}" @ONLY)
+
 catkin_package(
   LIBRARIES ${PROJECT_NAME}
   INCLUDE_DIRS include ${TinyXML_INLCLUDE_DIRS} ${CATKIN_DEVEL_PREFIX}/include
   CATKIN_DEPENDS rosconsole_bridge roscpp
   DEPENDS urdfdom_headers urdfdom Boost
 )
-
-
-### for Wily: maintain compatibility between urdfdom 0.3 and 0.4 (definining SharedPtr types)
-if( "0.4.0" VERSION_GREATER "${urdfdom_headers_VERSION}")
-  set(HAVE_URDFDOM_4 0)
-else()
-  set(HAVE_URDFDOM_4 1)
-endif()
-set(generated_compat_header "${CATKIN_DEVEL_PREFIX}/include/${PROJECT_NAME}/urdfdom_compatibility.h")
-include_directories("${CATKIN_DEVEL_PREFIX}/include")
-configure_file(urdfdom_compatibility.h.in "${generated_compat_header}" @ONLY)
 install(FILES ${generated_compat_header} DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
 
 

--- a/urdf/include/urdf/model.h
+++ b/urdf/include/urdf/model.h
@@ -40,6 +40,7 @@
 #include <string>
 #include <map>
 #include <urdf_model/model.h>
+#include <urdf/urdfdom_compatibility.h>
 #include <tinyxml.h>
 #include <boost/shared_ptr.hpp>
 #include <boost/weak_ptr.hpp>

--- a/urdf/urdfdom_compatibility.h.in
+++ b/urdf/urdfdom_compatibility.h.in
@@ -37,10 +37,7 @@
 #ifndef URDF_URDFDOM_COMPATIBILITY_
 #define URDF_URDFDOM_COMPATIBILITY_
 
-// This code is only activated when urdfdom's type forwards were not available
-// at cmake configuration time
-
-#if @HAVE_URDFDOM_4@ == 0
+#if @URDFDOM_DECLARE_TYPES@ // This is needed for urdfdom <= 0.4
 
 #include <boost/shared_ptr.hpp>
 #include <boost/weak_ptr.hpp>
@@ -70,9 +67,18 @@ URDF_TYPEDEF_CLASS_POINTER(Material);
 URDF_TYPEDEF_CLASS_POINTER(Mesh);
 URDF_TYPEDEF_CLASS_POINTER(Sphere);
 URDF_TYPEDEF_CLASS_POINTER(Visual);
+
+URDF_TYPEDEF_CLASS_POINTER(ModelInterface);
 }
 
 #undef URDF_TYPEDEF_CLASS_POINTER
 
-#endif
+#else // urdfdom <= 0.4
+
+typedef std::shared_ptr<ModelInterface> ModelInterfaceSharedPtr;
+typedef std::shared_ptr<const ModelInterface> ModelInterfaceConstSharedPtr;
+typedef std::weak_ptr<ModelInterface> ModelInterfaceWeakPtr;
+
+#endif // urdfdom > 0.4
+
 #endif // URDF_URDFDOM_COMPATIBILITY_

--- a/urdf/urdfdom_compatibility.h.in
+++ b/urdf/urdfdom_compatibility.h.in
@@ -1,0 +1,78 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2016, CITEC, Bielefeld University
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the Willow Garage nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+/* Robert Haschke */
+
+#ifndef URDF_URDFDOM_COMPATIBILITY_
+#define URDF_URDFDOM_COMPATIBILITY_
+
+// This code is only activated when urdfdom's type forwards were not available
+// at cmake configuration time
+
+#if @HAVE_URDFDOM_4@ == 0
+
+#include <boost/shared_ptr.hpp>
+#include <boost/weak_ptr.hpp>
+
+#define URDF_TYPEDEF_CLASS_POINTER(Class) \
+class Class; \
+typedef boost::shared_ptr<Class> Class##SharedPtr; \
+typedef boost::shared_ptr<const Class> Class##ConstSharedPtr; \
+typedef boost::weak_ptr<Class> Class##WeakPtr
+
+namespace urdf {
+URDF_TYPEDEF_CLASS_POINTER(Box);
+URDF_TYPEDEF_CLASS_POINTER(Collision);
+URDF_TYPEDEF_CLASS_POINTER(Cylinder);
+URDF_TYPEDEF_CLASS_POINTER(Geometry);
+URDF_TYPEDEF_CLASS_POINTER(Inertial);
+
+URDF_TYPEDEF_CLASS_POINTER(Joint);
+URDF_TYPEDEF_CLASS_POINTER(JointCalibration);
+URDF_TYPEDEF_CLASS_POINTER(JointDynamics);
+URDF_TYPEDEF_CLASS_POINTER(JointLimits);
+URDF_TYPEDEF_CLASS_POINTER(JointMimic);
+URDF_TYPEDEF_CLASS_POINTER(JointSafety);
+
+URDF_TYPEDEF_CLASS_POINTER(Link);
+URDF_TYPEDEF_CLASS_POINTER(Material);
+URDF_TYPEDEF_CLASS_POINTER(Mesh);
+URDF_TYPEDEF_CLASS_POINTER(Sphere);
+URDF_TYPEDEF_CLASS_POINTER(Visual);
+}
+
+#undef URDF_TYPEDEF_CLASS_POINTER
+
+#endif
+#endif // URDF_URDFDOM_COMPATIBILITY_


### PR DESCRIPTION
Wily ships with urdfdom 0.3, which doesn't yet declare SharedPtr types. To allow compatibility of Kinetic packages, which typically already rely on those types, we ship a `urdf_compatibility.h` header.

@wjwwood suggested to apply this PR here, in the very first ROS package using urdfdom, and not in downstream packages like MoveIt: https://github.com/ros-planning/moveit/issues/18#issuecomment-256436686.

Downstream packages simply need to `#include <urdf/urdf_compatibility.h>`.
