### PR TITLE
Allow supplying NodeHandle for initParam

### DIFF
--- a/urdf/include/urdf/model.h
+++ b/urdf/include/urdf/model.h
@@ -44,6 +44,7 @@
 #include <tinyxml.h>
 #include <boost/shared_ptr.hpp>
 #include <boost/weak_ptr.hpp>
+#include <ros/ros.h>
 
 namespace urdf{
 
@@ -58,6 +59,8 @@ public:
   bool initFile(const std::string& filename);
   /// \brief Load Model given the name of a parameter on the parameter server
   bool initParam(const std::string& param);
+  /// \brief Load Model given the name of a parameter on the parameter server using provided nodehandle
+  bool initParamWithNodeHandle(const std::string& param, const ros::NodeHandle& nh = ros::NodeHandle());
   /// \brief Load Model from a XML-string
   bool initString(const std::string& xmlstring);
 };

--- a/urdf/src/model.cpp
+++ b/urdf/src/model.cpp
@@ -36,8 +36,6 @@
 
 #include "urdf/model.h"
 
-#include <ros/ros.h>
-
 /* we include the default parser for plain URDF files; 
    other parsers are loaded via plugins (if available) */
 #include <urdf_parser/urdf_parser.h>
@@ -88,7 +86,11 @@ bool Model::initFile(const std::string& filename)
 
 bool Model::initParam(const std::string& param)
 {
-  ros::NodeHandle nh;
+  initParamWithNodeHandle(param, ros::NodeHandle());
+}
+
+bool Model::initParamWithNodeHandle(const std::string& param, const ros::NodeHandle& nh)
+{
   std::string xml_string;
   
   // gets the location of the robot description on the parameter server

--- a/urdf/src/model.cpp
+++ b/urdf/src/model.cpp
@@ -86,7 +86,7 @@ bool Model::initFile(const std::string& filename)
 
 bool Model::initParam(const std::string& param)
 {
-  initParamWithNodeHandle(param, ros::NodeHandle());
+  return initParamWithNodeHandle(param, ros::NodeHandle());
 }
 
 bool Model::initParamWithNodeHandle(const std::string& param, const ros::NodeHandle& nh)


### PR DESCRIPTION
Previously, initParam always constructs a default NodeHandle, which
works correctly as long as robot_description param and the node
calling initParam are in the same namespace. This is not true,
when initParam is called via a ros_control controller running in
the global namespace (gazebo), but robot_descriptions still need
to be namespaced. This backwards compatible change allows setting
the NodeHandle.

See https://github.com/ros-controls/ros_controllers/issues/244