### PR TITLE
fix missed mandatory -std=c++11 flag

### DIFF
--- a/collada_parser/CMakeLists.txt
+++ b/collada_parser/CMakeLists.txt
@@ -6,6 +6,8 @@ find_package(Boost REQUIRED system)
 find_package(catkin REQUIRED COMPONENTS urdf_parser_plugin roscpp class_loader urdf)
 find_package(urdfdom_headers REQUIRED)
 
+add_compile_options(-std=c++11)
+
 catkin_package( 
   LIBRARIES ${PROJECT_NAME}
   INCLUDE_DIRS include

--- a/collada_parser/src/collada_parser.cpp
+++ b/collada_parser/src/collada_parser.cpp
@@ -42,8 +42,13 @@
 #include <string>
 #include <sstream>
 
+/* disable deprecated auto_ptr warnings */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #include <dae.h>
 #include <dae/daeErrorHandler.h>
+#pragma GCC diagnostic pop
+
 #include <dom/domCOLLADA.h>
 #include <dae/domAny.h>
 #include <dom/domConstants.h>
@@ -67,6 +72,7 @@
 #include <fcntl.h>
 #endif
 
+#define typeof __typeof__
 #define FOREACH(it, v) for(typeof((v).begin())it = (v).begin(); it != (v).end(); (it)++)
 #define FOREACHC FOREACH
 

--- a/kdl_parser/CMakeLists.txt
+++ b/kdl_parser/CMakeLists.txt
@@ -19,6 +19,8 @@ link_directories(${Boost_LIBRARY_DIRS})
 
 find_library(KDL_LIBRARY REQUIRED NAMES orocos-kdl HINTS ${orocos_kdl_LIBRARY_DIRS})
 
+add_compile_options(-std=c++11)
+
 catkin_package(
   LIBRARIES ${PROJECT_NAME} ${KDL_LIBRARY}
   INCLUDE_DIRS include

--- a/urdf/CMakeLists.txt
+++ b/urdf/CMakeLists.txt
@@ -21,6 +21,8 @@ set(generated_compat_header "${CATKIN_DEVEL_PREFIX}/include/${PROJECT_NAME}/urdf
 include_directories("${CATKIN_DEVEL_PREFIX}/include")
 configure_file(urdfdom_compatibility.h.in "${generated_compat_header}" @ONLY)
 
+add_compile_options(-std=c++11)
+
 catkin_package(
   LIBRARIES ${PROJECT_NAME}
   INCLUDE_DIRS include ${TinyXML_INLCLUDE_DIRS} ${CATKIN_DEVEL_PREFIX}/include

--- a/urdf/test/test_robot_model_parser.cpp
+++ b/urdf/test/test_robot_model_parser.cpp
@@ -94,7 +94,7 @@ protected:
         double roll,pitch,yaw;
         (*child)->parent_joint->parent_to_joint_origin_transform.rotation.getRPY(roll,pitch,yaw);
 
-        if (isnan(roll) || isnan(pitch) || isnan(yaw))
+        if (std::isnan(roll) || std::isnan(pitch) || std::isnan(yaw))
         {
           ROS_ERROR("getRPY() returned nan!");
           return false;


### PR DESCRIPTION
collada_parser,kdl_parser,urdf: add c++11 flag,
collada_parser: replace typeof with ansi __typeof__
builded/tested on gentoo