### PR TITLE
[joint_state_publisher] Handle time moving backwards

### DIFF
--- a/joint_state_publisher/joint_state_publisher/joint_state_publisher
+++ b/joint_state_publisher/joint_state_publisher/joint_state_publisher
@@ -209,7 +209,10 @@ class JointStatePublisher():
                     msg.effort[i] = joint['effort']
 
             self.pub.publish(msg)
-            r.sleep()
+            try:
+                r.sleep()
+            except rospy.exceptions.ROSTimeMovedBackwardsException:
+                pass
 
     def update(self, delta):
         for name, joint in self.free_joints.iteritems():


### PR DESCRIPTION
Without this patch, joint_state_publisher dies whenever the ROS time moves backwards (e.g., when running `rosbag play --clock --loop`).