### PR TITLE
Change urdf::Model to use std::shared_ptrs in urdfdom > v0.4

### DIFF
--- a/urdf/include/urdf/model.h
+++ b/urdf/include/urdf/model.h
@@ -1,13 +1,13 @@
 /*********************************************************************
 * Software License Agreement (BSD License)
-* 
+*
 *  Copyright (c) 2008, Willow Garage, Inc.
 *  All rights reserved.
-* 
+*
 *  Redistribution and use in source and binary forms, with or without
 *  modification, are permitted provided that the following conditions
 *  are met:
-* 
+*
 *   * Redistributions of source code must retain the above copyright
 *     notice, this list of conditions and the following disclaimer.
 *   * Redistributions in binary form must reproduce the above
@@ -17,7 +17,7 @@
 *   * Neither the name of the Willow Garage nor the names of its
 *     contributors may be used to endorse or promote products derived
 *     from this software without specific prior written permission.
-* 
+*
 *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
@@ -65,9 +65,7 @@ public:
   bool initString(const std::string& xmlstring);
 };
 
-typedef boost::shared_ptr<Model> ModelSharedPtr;
-typedef boost::shared_ptr<const Model> ModelConstSharedPtr;
-typedef boost::weak_ptr<Model> ModelWeakPtr;
+// shared_ptr declarations moved to urdf/urdfdom_compatibility.h to allow for std::shared_ptrs in latest version
 
 }
 

--- a/urdf/urdfdom_compatibility.h.in
+++ b/urdf/urdfdom_compatibility.h.in
@@ -74,6 +74,7 @@ URDF_TYPEDEF_CLASS_POINTER(Sphere);
 URDF_TYPEDEF_CLASS_POINTER(Visual);
 
 URDF_TYPEDEF_CLASS_POINTER(ModelInterface);
+URDF_TYPEDEF_CLASS_POINTER(Model);
 }
 
 #undef URDF_TYPEDEF_CLASS_POINTER
@@ -87,6 +88,10 @@ namespace urdf {
 typedef std::shared_ptr<ModelInterface> ModelInterfaceSharedPtr;
 typedef std::shared_ptr<const ModelInterface> ModelInterfaceConstSharedPtr;
 typedef std::weak_ptr<ModelInterface> ModelInterfaceWeakPtr;
+
+typedef std::shared_ptr<Model> ModelSharedPtr;
+typedef std::shared_ptr<const Model> ModelConstSharedPtr;
+typedef std::weak_ptr<Model> ModelWeakPtr;
 }
 
 #endif // urdfdom > 0.4


### PR DESCRIPTION
In the latest ROS Lunar version of URDFDom all shared_ptr typedefs were converted to ``std::`` from ``boost::`` *except* one was forgotten - ``urdf::Model``. This class [inherits](https://github.com/ros/robot_model/blob/kinetic-devel/urdf/include/urdf/model.h#L51) from ``urdf::Modelnterface`` which is using a ``std::shared_ptr``, so it seems to me this should be fixed despite Lunar already being released. In this PR I propose we maintain the boost shared ptr in Kinetic but allow for an std shared ptr in Lunar. 

This change is not a big deal because the typedefs being changed were only [added in Sep 2016](https://github.com/ros/robot_model/commit/f8cb99cd0f70c4d4b4402b4d0f259369a5f77632) by @bmagyar - way after Kinetic was released - so there should be almost no existing code affected by this.

This is important for MoveIt because currently this bug is blocking our full [Lunar release](https://github.com/ros-planning/moveit/issues/506) due to this [line](https://github.com/ros-planning/moveit/blob/kinetic-devel/moveit_setup_assistant/src/tools/moveit_config_data.cpp#L186) where a ``urdf::ModelSharedPtr`` is downcast into a ``urdf::ModelInterfaceSharedPtr``. This won't work since one is boost and one is std.

I've tested this change with MoveIt in Kinetic and Lunar and it fixes our issue.