### PR TITLE
add missing ModelSharedPtr typedefs in indigo

### DIFF
--- a/urdf/urdfdom_compatibility.h.in
+++ b/urdf/urdfdom_compatibility.h.in
@@ -74,6 +74,8 @@ URDF_TYPEDEF_CLASS_POINTER(Sphere);
 URDF_TYPEDEF_CLASS_POINTER(Visual);
 
 URDF_TYPEDEF_CLASS_POINTER(ModelInterface);
+
+URDF_TYPEDEF_CLASS_POINTER(Model);
 }
 
 #undef URDF_TYPEDEF_CLASS_POINTER
@@ -87,6 +89,10 @@ namespace urdf {
 typedef std::shared_ptr<ModelInterface> ModelInterfaceSharedPtr;
 typedef std::shared_ptr<const ModelInterface> ModelInterfaceConstSharedPtr;
 typedef std::weak_ptr<ModelInterface> ModelInterfaceWeakPtr;
+
+typedef std::shared_ptr<Model> ModelSharedPtr;
+typedef std::shared_ptr<const Model> ModelConstSharedPtr;
+typedef std::weak_ptr<Model> ModelWeakPtr;
 }
 
 #endif // urdfdom > 0.4


### PR DESCRIPTION
In the kinetic-devel branch #153 introduced typedefs
for the `Model` class of this package.
Later, #206 moved these typedefs over to the
`urdfdom_compatibility.h` header.

The main purpose of this header is to ease compatibility between indigo
and kinetic+, so these typedefs should also be provided in indigo-devel.

After we merged [this patch for ROS lunar](https://github.com/ros-planning/moveit/pull/542) in MoveIt,
the missing typedefs break the build of our `kinetic-devel` on ROS indigo.
I guess we are not the only affected project though.

It would be great to see this merged and released in indigo soon!