### PR TITLE
Optionally select joints via parameter.

### DIFF
--- a/joint_state_publisher/joint_state_publisher/joint_state_publisher
+++ b/joint_state_publisher/joint_state_publisher/joint_state_publisher
@@ -45,6 +45,7 @@ class JointStatePublisher():
         robot = xml.dom.minidom.parseString(description).getElementsByTagName('robot')[0]
         self.free_joints = {}
         self.joint_list = []  # for maintaining the original order of the joints
+        self.selected_joints = get_param("selected_joints", {})
         self.dependent_joints = get_param("dependent_joints", {})
         use_mimic = get_param('use_mimic_tags', True)
         use_small = get_param('use_smallest_joint_limits', True)
@@ -64,6 +65,11 @@ class JointStatePublisher():
                 if jtype == 'fixed' or jtype == 'floating':
                     continue
                 name = child.getAttribute('name')
+                
+                if any(self.selected_joints):
+                  if name not in self.selected_joints:
+                    continue
+                
                 self.joint_list.append(name)
                 if jtype == 'continuous':
                     minval = -pi


### PR DESCRIPTION
This PR optionally allows specifying the joints to be used by the joint_state_publisher, example usage:

```
<node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">  
  <param name="selected_joints" value="gripper_roll_joint gripper_finger_servo_joint" />
  <param name="use_gui" value="true" />
</node>
```

This can come in very handy, for instance when working with bag files and some parts of the robot joint state are missing. If the `selected_joints` param is not set, the behavior of the node is exactly the same as before this PR.