### PR TITLE
[urdf] add missing build/build_export/run dependency on tinyxml

### DIFF
--- a/urdf/CMakeLists.txt
+++ b/urdf/CMakeLists.txt
@@ -25,7 +25,7 @@ add_compile_options(-std=c++11)
 
 catkin_package(
   LIBRARIES ${PROJECT_NAME}
-  INCLUDE_DIRS include ${TinyXML_INLCLUDE_DIRS} ${CATKIN_DEVEL_PREFIX}/include
+  INCLUDE_DIRS include ${CATKIN_DEVEL_PREFIX}/include
   CATKIN_DEPENDS rosconsole_bridge roscpp
   DEPENDS urdfdom_headers urdfdom Boost TinyXML
 )

--- a/urdf/CMakeLists.txt
+++ b/urdf/CMakeLists.txt
@@ -27,7 +27,7 @@ catkin_package(
   LIBRARIES ${PROJECT_NAME}
   INCLUDE_DIRS include ${TinyXML_INLCLUDE_DIRS} ${CATKIN_DEVEL_PREFIX}/include
   CATKIN_DEPENDS rosconsole_bridge roscpp
-  DEPENDS urdfdom_headers urdfdom Boost
+  DEPENDS urdfdom_headers urdfdom Boost TinyXML
 )
 install(FILES ${generated_compat_header} DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
 

--- a/urdf/package.xml
+++ b/urdf/package.xml
@@ -29,6 +29,9 @@
   <build_depend>pluginlib</build_depend>
   <build_depend>cmake_modules</build_depend>
   <build_depend>rostest</build_depend>
+  <build_depend>tinyxml</build_depend>
+
+  <build_export_depend>tinyxml</build_export_depend>
 
   <run_depend>liburdfdom-dev</run_depend>
   <run_depend>liburdfdom-headers-dev</run_depend>
@@ -36,5 +39,6 @@
   <run_depend>roscpp</run_depend>
   <run_depend>urdf_parser_plugin</run_depend>
   <run_depend>pluginlib</run_depend>
+  <run_depend>tinyxml</run_depend>
 
 </package>

--- a/urdf/package.xml
+++ b/urdf/package.xml
@@ -31,8 +31,6 @@
   <build_depend>rostest</build_depend>
   <build_depend>tinyxml</build_depend>
 
-  <build_export_depend>tinyxml</build_export_depend>
-
   <run_depend>liburdfdom-dev</run_depend>
   <run_depend>liburdfdom-headers-dev</run_depend>
   <run_depend>rosconsole_bridge</run_depend>


### PR DESCRIPTION
urdf expose tinyxml symbols in its public API. Thus it needs to declare the dependency and export it to downstream packages