### PR TITLE
add forward declaration for Model

### DIFF
--- a/urdf/urdfdom_compatibility.h.in
+++ b/urdf/urdfdom_compatibility.h.in
@@ -90,6 +90,9 @@ typedef std::shared_ptr<ModelInterface> ModelInterfaceSharedPtr;
 typedef std::shared_ptr<const ModelInterface> ModelInterfaceConstSharedPtr;
 typedef std::weak_ptr<ModelInterface> ModelInterfaceWeakPtr;
 
+// Forward declaration
+class Model;
+
 typedef std::shared_ptr<Model> ModelSharedPtr;
 typedef std::shared_ptr<const Model> ModelConstSharedPtr;
 typedef std::weak_ptr<Model> ModelWeakPtr;


### PR DESCRIPTION
Selective backport of 530684564fb70e3bd704c4aaac7778318ef2c1a6
Without this, some indigo packages fail for no reason when compiled
with a more recent urdfdom.