### PR TITLE
Remove the default parameter from initParamWithNodeHandle.

### DIFF
--- a/urdf/include/urdf/model.h
+++ b/urdf/include/urdf/model.h
@@ -60,7 +60,7 @@ public:
   /// \brief Load Model given the name of a parameter on the parameter server
   bool initParam(const std::string& param);
   /// \brief Load Model given the name of a parameter on the parameter server using provided nodehandle
-  bool initParamWithNodeHandle(const std::string& param, const ros::NodeHandle& nh = ros::NodeHandle());
+  bool initParamWithNodeHandle(const std::string& param, const ros::NodeHandle& nh);
   /// \brief Load Model from a XML-string
   bool initString(const std::string& xmlstring);
 };


### PR DESCRIPTION
It's silly to have a default parameter there because we already
have an API that works without a node handle (initParam).  Thus,
remove the default nature of this.  This brings melodic back
into line with what indigo does.  I've tested all of the first
level dependencies of urdf, and none of them depend on this
behavior, so I think this will be safe to do.

Signed-off-by: Chris Lalancette <clalancette@osrfoundation.org>